### PR TITLE
Camera permission dialog

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -65,6 +65,14 @@
 		079F30FE26EA0F9600ED96D3 /* MailHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F30FC26EA0F9600ED96D3 /* MailHelper.swift */; };
 		079F30FF26EA0F9600ED96D3 /* MailHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F30FC26EA0F9600ED96D3 /* MailHelper.swift */; };
 		079F310026EA0F9600ED96D3 /* MailHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F30FC26EA0F9600ED96D3 /* MailHelper.swift */; };
+		079F310226EB5A2D00ED96D3 /* CameraHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310126EB5A2D00ED96D3 /* CameraHelper.swift */; };
+		079F310326EB5A2D00ED96D3 /* CameraHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310126EB5A2D00ED96D3 /* CameraHelper.swift */; };
+		079F310426EB5A2D00ED96D3 /* CameraHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310126EB5A2D00ED96D3 /* CameraHelper.swift */; };
+		079F310526EB5A2D00ED96D3 /* CameraHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310126EB5A2D00ED96D3 /* CameraHelper.swift */; };
+		079F310726EB69DD00ED96D3 /* SettingsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310626EB69DD00ED96D3 /* SettingsHelper.swift */; };
+		079F310826EB69DD00ED96D3 /* SettingsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310626EB69DD00ED96D3 /* SettingsHelper.swift */; };
+		079F310926EB69DD00ED96D3 /* SettingsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310626EB69DD00ED96D3 /* SettingsHelper.swift */; };
+		079F310A26EB69DD00ED96D3 /* SettingsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F310626EB69DD00ED96D3 /* SettingsHelper.swift */; };
 		0D57DEAB78857280454239BD /* Pods_ProdTestNet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14CFDAC6FBD35E46353538FC /* Pods_ProdTestNet.framework */; };
 		108974343BB3D4418ABDA331 /* Pods_Mock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFD4DEA6863F11D37DDBAFFA /* Pods_Mock.framework */; };
 		1737681A2652A87C00A48758 /* TermsAndConditionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173768192652A87C00A48758 /* TermsAndConditionsViewController.swift */; };
@@ -1410,6 +1418,8 @@
 		077AC5FD26E8E1E40016BF26 /* CopyPasteHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyPasteHelper.swift; sourceTree = "<group>"; };
 		077FD7DB269EC49200EE749C /* SupportMailProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportMailProtocol.swift; sourceTree = "<group>"; };
 		079F30FC26EA0F9600ED96D3 /* MailHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailHelper.swift; sourceTree = "<group>"; };
+		079F310126EB5A2D00ED96D3 /* CameraHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraHelper.swift; sourceTree = "<group>"; };
+		079F310626EB69DD00ED96D3 /* SettingsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHelper.swift; sourceTree = "<group>"; };
 		0ACC4D18CC7B5F1FA9EFB00F /* Pods-ProdMainNet.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ProdMainNet.debug.xcconfig"; path = "Target Support Files/Pods-ProdMainNet/Pods-ProdMainNet.debug.xcconfig"; sourceTree = "<group>"; };
 		129C295B179589B8BF15F2F8 /* Pods_StagingNet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StagingNet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14CFDAC6FBD35E46353538FC /* Pods_ProdTestNet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProdTestNet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2636,6 +2646,7 @@
 		7FF07A8F23EADBB100F1FC04 /* Commons */ = {
 			isa = PBXGroup;
 			children = (
+				079F310126EB5A2D00ED96D3 /* CameraHelper.swift */,
 				077AC5FD26E8E1E40016BF26 /* CopyPasteHelper.swift */,
 				07619A80269C810B009B79E2 /* Digest+Additions.swift */,
 				07619A7B269C63C4009B79E2 /* HashingHelper.swift */,
@@ -2644,6 +2655,7 @@
 				079F30FC26EA0F9600ED96D3 /* MailHelper.swift */,
 				19C2E3CBC386A0EB2A37AA82 /* Publisher+Utils.swift */,
 				19C2EBFC473BE97DBED4FCC8 /* Result+Additions.swift */,
+				079F310626EB69DD00ED96D3 /* SettingsHelper.swift */,
 				C9D342B8245884AA007ED45E /* ShowErrorProtocol.swift */,
 				19C2EB40B942873B4D0E2288 /* ShowToastProtocol.swift */,
 				19C2ED4F802767556C4ABBE9 /* SingleSection.swift */,
@@ -3437,6 +3449,7 @@
 				52589B2625128F8700ADD35B /* AccountMultiBalanceCell.swift in Sources */,
 				528EB754256400C400010554 /* RevealAttributesViewController.swift in Sources */,
 				07619A81269C810B009B79E2 /* Digest+Additions.swift in Sources */,
+				079F310726EB69DD00ED96D3 /* SettingsHelper.swift in Sources */,
 				7F48C143244DCD0B00997684 /* PasscodeFieldViewController.swift in Sources */,
 				7F48C261244E17D100997684 /* ChoiceArData.swift in Sources */,
 				7F48C275244E17D100997684 /* Metadata.swift in Sources */,
@@ -3520,6 +3533,7 @@
 				7F48C17B244DCD0B00997684 /* AccountsViewController.swift in Sources */,
 				7F32341324691B540019A351 /* MenuItemCellView.swift in Sources */,
 				5211BAA324FD1D5100EE1658 /* AccountEncryptedAmount.swift in Sources */,
+				079F310226EB5A2D00ED96D3 /* CameraHelper.swift in Sources */,
 				7F48C17F244DCD0B00997684 /* IdentityDataRowCellView.swift in Sources */,
 				7F48C181244DCD0B00997684 /* IdentityProviderListViewController.swift in Sources */,
 				C96632562459B9260087A1F2 /* AccountTransactionsDataCellView.swift in Sources */,
@@ -3937,6 +3951,7 @@
 				7F85B791246A9A7C00ED09B8 /* SubmissionStatusEnum.swift in Sources */,
 				7F85B792246A9A7C00ED09B8 /* Result+Additions.swift in Sources */,
 				7F85B793246A9A7C00ED09B8 /* ErrorMapper.swift in Sources */,
+				079F310926EB69DD00ED96D3 /* SettingsHelper.swift in Sources */,
 				7F85B794246A9A7C00ED09B8 /* LoginPresenter.swift in Sources */,
 				642A293325FB967A0073BF8C /* ValueCredential.swift in Sources */,
 				7F85B8EF2472D39400ED09B8 /* MoreCoordinator.swift in Sources */,
@@ -4024,6 +4039,7 @@
 				19C2E4034C5A942BE94EFD73 /* ExportContainer.swift in Sources */,
 				19C2EBBA614AB2996127C30C /* CreateExportPasswordPresenter.swift in Sources */,
 				19C2E7AA27024C4F32B39273 /* ExportPresenter.swift in Sources */,
+				079F310426EB5A2D00ED96D3 /* CameraHelper.swift in Sources */,
 				7FCA399A250BFB39004567C4 /* ImportReceiptViewController.swift in Sources */,
 				528EB742255C1EC600010554 /* InitialAccountSummaryViewController.swift in Sources */,
 				19C2EAA10B0289BB2E451EEA /* ExportService.swift in Sources */,
@@ -4249,6 +4265,7 @@
 				7F85B88D246A9AB600ED09B8 /* UIView+Additions.swift in Sources */,
 				7F85B88E246A9AB600ED09B8 /* PasswordFieldViewController.swift in Sources */,
 				7F85B88F246A9AB600ED09B8 /* Sizes.swift in Sources */,
+				079F310A26EB69DD00ED96D3 /* SettingsHelper.swift in Sources */,
 				7F85B890246A9AB600ED09B8 /* SubmissionStatusEnum.swift in Sources */,
 				642A293425FB967A0073BF8C /* ValueCredential.swift in Sources */,
 				7F85B891246A9AB600ED09B8 /* Result+Additions.swift in Sources */,
@@ -4336,6 +4353,7 @@
 				19C2E7649714190CA01BA378 /* MockedData.swift in Sources */,
 				19C2EAAD7644A803CCE64786 /* EncryptionMetadata.swift in Sources */,
 				19C2E693A35A80A8317F32D8 /* ExportContainer.swift in Sources */,
+				079F310526EB5A2D00ED96D3 /* CameraHelper.swift in Sources */,
 				7FCA399B250BFB39004567C4 /* ImportReceiptViewController.swift in Sources */,
 				528EB743255C1EC600010554 /* InitialAccountSummaryViewController.swift in Sources */,
 				19C2E97D649F0F8D782DCA6B /* CreateExportPasswordPresenter.swift in Sources */,
@@ -4476,6 +4494,7 @@
 				C9BB9FE12444AB3900AE0884 /* GeneralFormatter.swift in Sources */,
 				7FF07AD423EADBB100F1FC04 /* BaseNavigationController.swift in Sources */,
 				068DC81423F2E6FC001B2975 /* TitleLabel.swift in Sources */,
+				079F310826EB69DD00ED96D3 /* SettingsHelper.swift in Sources */,
 				529531B2256BA711004CECE4 /* Schedule.swift in Sources */,
 				528EB76425647DD800010554 /* Key.swift in Sources */,
 				7FF91913250E571900B1032B /* ImportStatusCell.swift in Sources */,
@@ -4600,6 +4619,7 @@
 				19C2EB74069A5C18BE3E0A27 /* SendFundViewController.swift in Sources */,
 				19C2E960F1FF0455D336825B /* SelectRecipientPresenter.swift in Sources */,
 				19C2EE4F9BADE3BCC1AF1358 /* SelectRecipientViewController.swift in Sources */,
+				079F310326EB5A2D00ED96D3 /* CameraHelper.swift in Sources */,
 				19C2ED4B9B793A090B70CF7F /* AddRecipientPresenter.swift in Sources */,
 				52CE0C7A250FFEC70018B5D1 /* Encrypted.swift in Sources */,
 				5211BAA824FD1D5100EE1658 /* Balance.swift in Sources */,

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -34,6 +34,7 @@ add_identity_data = "Reveal Identity Data";
 "viewError.duplicateRecipient" = "This account was not added to the address book, as it was already saved as ";
 "viewError.passwordChangeFailed" = "An error occured while changing password";
 "viewError.jailbroken" = "This iPhone might be jailbroken. Using this iPhone is not safe.";
+"view.error.cameraAccessDenued" = "Camera access has been denied, and must be enabled in the Settings app to continue";
 "keychain.popup.button.enterpassword" = "Enter Password";
 "keychain.popup.button.enterpasscode" = "Enter Passcode";
 "selectPassword.button.useFullPassword" = "Use full password instead";

--- a/ConcordiumWallet/Service/ErrorMapper.swift
+++ b/ConcordiumWallet/Service/ErrorMapper.swift
@@ -16,6 +16,7 @@ enum ViewError: Error {
     case networkCommunicationError
     case duplicateRecipient(name: String)
     case exportUnfinalizedAccounts(unfinalizedAccountsNames: [String])
+    case cameraAccessDeniedError
 }
 
 extension ViewError: LocalizedError {
@@ -45,6 +46,8 @@ extension ViewError: LocalizedError {
             return "viewError.duplicateRecipient".localized + name
         case .exportUnfinalizedAccounts(let unfinalizedAccountsNames):
             return "export.unfinalizedAccounts".localized + unfinalizedAccountsNames.joined(separator: ", ")
+        case .cameraAccessDeniedError:
+            return "view.error.cameraAccessDenued".localized
         }
     }
 }

--- a/ConcordiumWallet/Views/Identities/CreateIdentity/IdentityProviderList/IdentityProviderListPresenter.swift
+++ b/ConcordiumWallet/Views/Identities/CreateIdentity/IdentityProviderList/IdentityProviderListPresenter.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import UIKit
 
 class IdentityGeneralViewModel: Hashable {
     var id: Int
@@ -121,6 +122,11 @@ extension IdentityProviderListPresenter: IdentityProviderListPresenterProtocol {
     }
     
     func userSelected(identityProviderIndex: Int) {
+        guard CameraHelper.isCameraAccessAllowed() else {
+            view?.showRecoverableAlert(.cameraAccessDeniedError) { SettingsHelper.openAppSettings() }
+            return
+        }
+        
         guard let delegate = delegate else { fatalError("Missing delegate in class IdentityProviderListPresenter") }
         guard let ipInfoResponse = ipInfo?[identityProviderIndex] else {
             fatalError("""

--- a/ioscommon/Commons/CameraHelper.swift
+++ b/ioscommon/Commons/CameraHelper.swift
@@ -1,0 +1,23 @@
+//
+//  CameraHelper.swift
+//  ConcordiumWallet
+//
+//  Created by Kristiyan Dobrev on 10/09/2021.
+//  Copyright © 2021 concordium. All rights reserved.
+//
+
+import AVFoundation
+import UIKit
+
+struct CameraHelper {
+    static func isCameraAccessAllowed() -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .denied, .restricted:
+            return false
+        case .authorized, .notDetermined:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/ioscommon/Commons/SettingsHelper.swift
+++ b/ioscommon/Commons/SettingsHelper.swift
@@ -1,0 +1,16 @@
+//
+//  SettingsHelper.swift
+//  ConcordiumWallet
+//
+//  Created by Kristiyan Dobrev on 10/09/2021.
+//  Copyright © 2021 concordium. All rights reserved.
+//
+
+import UIKit
+
+struct SettingsHelper {
+    static func openAppSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}


### PR DESCRIPTION
## Purpose

Prompting error dialog when choosing identity provider (during identity creation flow) if the camera permissions are either `denied` or `restricted`

Closes #24 