### PR TITLE
Cleanup both identities and accounts if flow is aborted

### DIFF
--- a/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
+++ b/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
@@ -111,10 +111,15 @@ class CreateIdentityCoordinator: Coordinator, ShowError {
     }
     
     private func cleanupUnfinishedAccounts() {
-        let unfinishedAccounts = dependencyProvider.storageManager().getAccounts().filter { $0.address == "" && $0.transactionStatus == .committed}
-        for account in unfinishedAccounts {
-            dependencyProvider.storageManager().removeAccount(account: account)
+        guard
+            let unfinishedAccount = dependencyProvider
+                .storageManager()
+                .getAccounts().first(where: { $0.identity == nil || $0.identity?.ipStatusUrl == nil || $0.identity?.state == .failed })
+        else {
+            return
         }
+        
+        dependencyProvider.storageManager().removeAccount(account: unfinishedAccount)
     }
     
     private func cleanupUnfinishedIdenties() {

--- a/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
+++ b/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
@@ -111,7 +111,7 @@ class CreateIdentityCoordinator: Coordinator, ShowError {
     }
     
     private func cleanupUnfinishedAccounts() {
-        let unfinishedAccounts = dependencyProvider.storageManager().getAccounts().filter { $0.address == "" || $0.transactionStatus == .committed}
+        let unfinishedAccounts = dependencyProvider.storageManager().getAccounts().filter { $0.address == "" && $0.transactionStatus == .committed}
         for account in unfinishedAccounts {
             dependencyProvider.storageManager().removeAccount(account: account)
         }


### PR DESCRIPTION
## Purpose

Making sure all identities and accounts are cleaned up if the identity creation flow is aborted by the user. 

Closes #35 