### PR TITLE
Cleanup accounts when app terminates

### DIFF
--- a/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
+++ b/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
@@ -35,12 +35,21 @@ class CreateIdentityCoordinator: Coordinator, ShowError {
         navigationController.modalPresentationStyle = .fullScreen
         showInitialAccountInfo()
         registerForCreatedIdentityNotification()
+        registerForApplicationWillTerminateNotification()
     }
 
     func startWithIdentity() {
         navigationController.modalPresentationStyle = .fullScreen
         showCreateNewIdentity()
         registerForCreatedIdentityNotification()
+        registerForApplicationWillTerminateNotification()
+    }
+    
+    private func registerForApplicationWillTerminateNotification() {
+        NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)
+            .sink { [weak self] _ in
+                self?.cleanupUnfinishedIdentiesAndAccounts()
+            }.store(in: &cancellables)
     }
     
     private func registerForCreatedIdentityNotification() {


### PR DESCRIPTION
## Purpose

@jens-concordium reported: 

> The camera permission thing is solved now, but it has lead to a new problem
> 
> So, if the permission is denied, the dialog is shown as intended. If the user then goes to the settings, allows the app to use the camera, and then goes back to the app, the intro flow is skipped and there is a "rogue" account in the Accounts page list

That happens because the (i)OS terminates the app each time a permission is toggled on or off. That might also happen if the user manually terminates the app.  To solve this issue we need to observe for the so called `willTerminate` event and respectively perform a cleanup. The cleanup includes calling the function discussed in https://github.com/Concordium/concordium-reference-wallet-ios/pull/44 