### PR TITLE
Check for commitments randomness while importing accounts from a file

### DIFF
--- a/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
@@ -87,6 +87,11 @@ class IdentityImporter {
                 account.transactionStatus = .finalized
             }
             account.revealedAttributes = accountData.revealedAttributes
+            
+            if let commitmentsRandomness = accountData.commitmentsRandomness {
+                account.encryptedCommitmentsRandomness = try storageManager.storeCommitmentsRandomness(commitmentsRandomness, pwHash: pwHash).get()
+            }
+            
             account.encryptedPrivateKey = try storageManager.storePrivateEncryptionKey(accountData.encryptionSecretKey, pwHash: pwHash).get()
             _ = try storageManager.storeAccount(account)
             importedIdentity.importedAccounts.append(accountData.name)


### PR DESCRIPTION
## Problem
Integration testing - Importing a file produced by the Android app (@jensvesti) did not include the randomness

## Root cause
 The reason for it was that the randomness was not taken into account while importing the file. 

## Solution
Simple check whether the import has randomness included or not