### PR TITLE
Include encryptionMethod and keyDerivationMethod in metadata

### DIFF
--- a/ConcordiumWallet/Model/Export/EncryptionMetadata.swift
+++ b/ConcordiumWallet/Model/Export/EncryptionMetadata.swift
@@ -6,9 +6,23 @@
 import Foundation
 
 struct EncryptionMetadata: Codable {
-        static let encryptionMethod = "AES-256"
-        static let keyDerivationMethod: String = "PBKDF2WithHmacSHA256"
-        let iterations: Int
-        let salt: String
-        let initializationVector: String
+    let encryptionMethod: String
+    let keyDerivationMethod: String
+    let iterations: Int
+    let salt: String
+    let initializationVector: String
+    
+    init(
+        encryptionMethod: String = "AES-256",
+        keyDerivationMethod: String = "PBKDF2WithHmacSHA256",
+        iterations: Int,
+        salt: String,
+        initializationVector: String
+    ) {
+        self.encryptionMethod = encryptionMethod
+        self.keyDerivationMethod = keyDerivationMethod
+        self.iterations = iterations
+        self.salt = salt
+        self.initializationVector = initializationVector
+    }
 }


### PR DESCRIPTION
## Problem

As mentioned in [here](#50) the `encryptionMethod` and `keyDerivationMethod` fields were missing from an export file. 

## Root cause

[Some time ago the fields were made static](https://github.com/Concordium/concordium-reference-wallet-ios/commit/f287e2b41580ba3253f92453d2fe2c9388a9c167#diff-dbe20a501ac086b56fee70e24926060357f3f1db4c310489158c5fb9de50222fR10)

## Solution

* Remove static modifiers 
* Set default values for `encryptionMethod` and `keyDerivationMethod` upon initialization

Closes #50 