### PR TITLE
Accounts identity cleanup

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -4836,7 +4836,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -4868,7 +4868,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";

--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -179,7 +179,7 @@ extension AppCoordinator: InitialAccountsCoordinatorDelegate {
 
 extension AppCoordinator: LoginCoordinatorDelegate {
     func loginDone() {
-        defaultProvider.storageManager().removeUnfinishedAccountsAndRelatedIdentities()
+        defaultProvider.storageManager().removeAccountsWithoutAddress()
         
         let identities = defaultProvider.storageManager().getIdentities()
         let accounts = defaultProvider.storageManager().getAccounts()

--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -80,33 +80,16 @@ class AppCoordinator: NSObject, Coordinator, ShowError, RequestPasswordDelegate 
         importCoordinator.navigationController.modalPresentationStyle = .fullScreen
 
         if navigationController.topPresented() is IdentityProviderWebViewViewController {
-            navigationController.dismiss(animated: true) {
-                self.presentImportView(importCoordinator: importCoordinator)
-                self.cleanupUnfinishedIdentiesAndAccounts()
+            navigationController.dismiss(animated: true) { [weak self] in
+                self?.presentImportView(importCoordinator: importCoordinator)
+                self?.defaultProvider.storageManager().removeUnfinishedAccountsAndRelatedIdentities()
             }
         } else {
             presentImportView(importCoordinator: importCoordinator)
-            self.cleanupUnfinishedAccounts()
+            defaultProvider.storageManager().removeAccountsWithoutAddress()
         }
     }
-
-    private func cleanupUnfinishedIdentiesAndAccounts() {
-        let unfinishedIdentities = defaultProvider.storageManager().getIdentities().filter { $0.ipStatusUrl .isEmpty }
-        for identity in unfinishedIdentities {
-            if let account = defaultProvider.storageManager().getAccounts(for: identity).first {
-                defaultProvider.storageManager().removeAccount(account: account)
-                defaultProvider.storageManager().removeIdentity(identity)
-            }
-        }
-    }
-
-    private func cleanupUnfinishedAccounts() {
-        let unfinishedAccounts = defaultProvider.storageManager().getAccounts().filter { $0.address .isEmpty}
-        for account in unfinishedAccounts {
-            defaultProvider.storageManager().removeAccount(account: account)
-        }
-    }
-
+    
     private func presentImportView(importCoordinator: ImportCoordinator) {
         navigationController.present(importCoordinator.navigationController, animated: true)
         importCoordinator.navigationController.presentationController?.delegate = self
@@ -196,6 +179,8 @@ extension AppCoordinator: InitialAccountsCoordinatorDelegate {
 
 extension AppCoordinator: LoginCoordinatorDelegate {
     func loginDone() {
+        defaultProvider.storageManager().removeUnfinishedAccountsAndRelatedIdentities()
+        
         let identities = defaultProvider.storageManager().getIdentities()
         let accounts = defaultProvider.storageManager().getAccounts()
         

--- a/ConcordiumWallet/Views/AccountsView/InitialAccount/InitialAccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/InitialAccount/InitialAccountsCoordinator.swift
@@ -86,7 +86,7 @@ extension InitialAccountsCoordinator: CreateNicknamePresenterDelegate {
         account.transactionStatus = .committed
         account.encryptedBalanceStatus = .decrypted
         do {
-            cleanupUnfinishedAccounts()
+            accountsProvider.storageManager().removeAccountsWithoutAddress()
             _ = try accountsProvider.storageManager().storeAccount(account)
         } catch {
             Logger.error(error)
@@ -94,13 +94,6 @@ extension InitialAccountsCoordinator: CreateNicknamePresenterDelegate {
         }
         
         showCreateNewIdentity()
-    }
-    
-    private func cleanupUnfinishedAccounts() {
-        let unfinishedAccounts = accountsProvider.storageManager().getAccounts().filter { $0.address == ""}
-        for account in unfinishedAccounts {
-            accountsProvider.storageManager().removeAccount(account: account)
-        }
     }
 }
 

--- a/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
+++ b/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
@@ -115,27 +115,8 @@ class CreateIdentityCoordinator: Coordinator, ShowError {
     }
     
     private func cleanupUnfinishedIdentiesAndAccounts() {
-        cleanupUnfinishedIdenties()
-        cleanupUnfinishedAccounts()
-    }
-    
-    private func cleanupUnfinishedAccounts() {
-        guard
-            let unfinishedAccount = dependencyProvider
-                .storageManager()
-                .getAccounts().first(where: { $0.identity == nil || $0.identity?.ipStatusUrl == nil || $0.identity?.state == .failed })
-        else {
-            return
-        }
-        
-        dependencyProvider.storageManager().removeAccount(account: unfinishedAccount)
-    }
-    
-    private func cleanupUnfinishedIdenties() {
-        let unfinishedIdentities = dependencyProvider.storageManager().getIdentities().filter { $0.ipStatusUrl.isEmpty }
-        for identity in unfinishedIdentities {
-            dependencyProvider.storageManager().removeIdentity(identity)
-        }
+        dependencyProvider.storageManager().removeUnfinishedIdentities()
+        dependencyProvider.storageManager().removeUnfinishedAccounts()
     }
 
     func showInitialAccountInfo() {
@@ -194,7 +175,7 @@ class CreateIdentityCoordinator: Coordinator, ShowError {
 
 extension CreateIdentityCoordinator: CreateNicknamePresenterDelegate {
     func createNicknamePresenterCancelled(_ presenter: CreateNicknamePresenter) {
-        cleanupUnfinishedAccounts()
+        dependencyProvider.storageManager().removeUnfinishedAccounts()
         parentCoordinator?.createNewIdentityCancelled()
     }
 
@@ -208,7 +189,7 @@ extension CreateIdentityCoordinator: CreateNicknamePresenterDelegate {
             account.transactionStatus = .committed
             account.encryptedBalanceStatus = .decrypted
             do {
-                cleanupUnfinishedAccounts()
+                dependencyProvider.storageManager().removeUnfinishedAccounts()
                 _ = try dependencyProvider.storageManager().storeAccount(account)
 
             } catch {


### PR DESCRIPTION
## Purpose

* Collect all cleanup funcs in `StorageManager`
* Cleanup accounts without address upon login*
* Bump project version (18)


_* That will cover the scenario when the user changes a permission from the `Settings` app and the iOS restarts the app. Unfortunately iOS does not provide us with such a system event and the best we can do is to basically cleanup the accounts without address upon login_

Closes #24 