### PR TITLE
Update identity issuance dialog

### DIFF
--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -387,4 +387,4 @@ idiss@concordium.software";
 "burgermenu.transferfilters" = "Transfer Filters";
 
 "supportmail.subject" = "Issuance reference: %@";
-"supportmail.body" = "My Concordium identity issuance failed with hashed session ID: %@";
+"supportmail.body" = "Hi! My identity issuance failed. \n\n Here is my info: \n\n Issuance reference: \n %@ \n\n Mobile Wallet version: \n %@ \n\n Platform: \n\n iOS: \n %@";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -387,4 +387,4 @@ idiss@concordium.software";
 "burgermenu.transferfilters" = "Transfer Filters";
 
 "supportmail.subject" = "Issuance reference: %@";
-"supportmail.body" = "Hi! My identity issuance failed. \n\n Here is my info: \n\n Issuance reference: \n %@ \n\n Mobile Wallet version: \n %@ \n\n Platform: \n\n iOS: \n %@";
+"supportmail.body" = "Hi! My identity issuance failed. \n\n Here is my info: \n\n Issuance reference: \n %@ \n\n Mobile Wallet version: \n %@ \n\n Platform: \n\n iOS: %@";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -365,8 +365,9 @@ process on-chain.";
 
 "identityfailed.title" = "Identity issuance failed";
 "identityfailed.tryagain" = "Try again";
-"identityfailed.message" = "Something went wrong while creating your identity. \n\n You can either try again, or contact Notabene’s support. \n\n Clicking Contact Support will open your e-mail app, with a reference to your submission as subject.";
-"identityfailed.nomail.message" = "The Mail app seems to be unavailable or not set up \n\n Instead you can copy your session reference, and then contact Notabene via concordium-idss@notabene.id";
+"identityfailed.message" = "The identity issuance failed. \n\n You can either try again, or contact Notabene’s support. \n\n Clicking Contact Support will open your e-mail app, with a reference to your submission as subject. \n\n Concordium will be CC’ed in the correspondence.";
+"identityfailed.nomail.message" = "The identity issuance failed. \n\n You can either try again, or contact Notabene’s support. \n\n You can copy the reference below, and then contact Notabene at concordium-idiss@notabene.id \n\n Optional: Add Concordium as CC via
+idiss@concordium.software";
 "identityfailed.copyreference" = "Copy reference";
 "identityfailed.contactsupport" = "Contact Support";
 

--- a/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
@@ -74,6 +74,8 @@
 	<string>Enable FaceID for more convenient login</string>
 	<key>Notabene Support Mail</key>
 	<string>concordium-idiss@notabene.id</string>
+	<key>Concordium Support Mail</key>
+	<string>idiss@concordium.software</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import UIKit
 
 enum PasswordType: String {
     case passcode
@@ -59,4 +60,10 @@ struct AppSettings {
             UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.dontShowMemoAlertWarning.rawValue)
         }
     }
+    
+    static var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
+    
+    static var iOSVersion: String { UIDevice.current.systemVersion }
 }

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -219,7 +219,7 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
                     recipient: AppConstants.Support.identityProviderSupportMail,
                     ccRecipient: AppConstants.Support.concordiumSupportMail,
                     subject: String(format: "supportmail.subject".localized, reference),
-                    body: String(format: "supportmail.body".localized, reference)
+                    body: String(format: "supportmail.body".localized, reference, AppSettings.appVersion, AppSettings.iOSVersion)
                 )
                 
             }

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -216,7 +216,8 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
                 self.launchSupport(
                     presenter: self,
                     delegate: self,
-                    recipient: AppConstants.Support.supportMail,
+                    recipient: AppConstants.Support.identityProviderSupportMail,
+                    ccRecipient: AppConstants.Support.concordiumSupportMail,
                     subject: String(format: "supportmail.subject".localized, reference),
                     body: String(format: "supportmail.body".localized, reference)
                 )

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
@@ -153,7 +153,7 @@ extension IdentitiesViewController: IdentitiesViewProtocol {
                     recipient: AppConstants.Support.identityProviderSupportMail,
                     ccRecipient: AppConstants.Support.concordiumSupportMail,
                     subject: String(format: "supportmail.subject".localized, reference),
-                    body: String(format: "supportmail.body".localized, reference)
+                    body: String(format: "supportmail.body".localized, reference, AppSettings.appVersion, AppSettings.iOSVersion)
                 )
             }
             ac.message = "identityfailed.message".localized

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
@@ -150,7 +150,8 @@ extension IdentitiesViewController: IdentitiesViewProtocol {
                 self.launchSupport(
                     presenter: self,
                     delegate: self,
-                    recipient: AppConstants.Support.supportMail,
+                    recipient: AppConstants.Support.identityProviderSupportMail,
+                    ccRecipient: AppConstants.Support.concordiumSupportMail,
                     subject: String(format: "supportmail.subject".localized, reference),
                     body: String(format: "supportmail.body".localized, reference)
                 )

--- a/ConcordiumWallet/Views/MoreSection/About/AboutViewController.swift
+++ b/ConcordiumWallet/Views/MoreSection/About/AboutViewController.swift
@@ -23,7 +23,7 @@ class AboutViewController: BaseViewController, AboutViewProtocol, Storyboarded, 
     @IBOutlet weak var websiteTextView: UITextView!
     @IBOutlet weak var versionLabel: UILabel! {
         didSet {
-            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+            let version = AppSettings.appVersion
             let buildNo = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
             versionLabel.text = "\(version).\(buildNo)"
         }

--- a/ConcordiumWallet/Views/Widgets/ContactSupportButtonWidgetViewController.swift
+++ b/ConcordiumWallet/Views/Widgets/ContactSupportButtonWidgetViewController.swift
@@ -49,7 +49,7 @@ class ContactSupportButtonWidgetViewController: BaseViewController, ContactSuppo
             recipient: AppConstants.Support.identityProviderSupportMail,
             ccRecipient: AppConstants.Support.concordiumSupportMail,
             subject: String(format: "supportmail.subject".localized, reference),
-            body: String(format: "supportmail.body".localized, reference)
+            body: String(format: "supportmail.body".localized, reference, AppSettings.appVersion, AppSettings.iOSVersion)
         )
     }
     

--- a/ConcordiumWallet/Views/Widgets/ContactSupportButtonWidgetViewController.swift
+++ b/ConcordiumWallet/Views/Widgets/ContactSupportButtonWidgetViewController.swift
@@ -46,7 +46,8 @@ class ContactSupportButtonWidgetViewController: BaseViewController, ContactSuppo
         launchSupport(
             presenter: self,
             delegate: self,
-            recipient: AppConstants.Support.supportMail,
+            recipient: AppConstants.Support.identityProviderSupportMail,
+            ccRecipient: AppConstants.Support.concordiumSupportMail,
             subject: String(format: "supportmail.subject".localized, reference),
             body: String(format: "supportmail.body".localized, reference)
         )

--- a/ioscommon/Base/AppConstants.swift
+++ b/ioscommon/Base/AppConstants.swift
@@ -18,6 +18,7 @@ struct AppConstants {
     
     // MARK: - Support
     struct Support {
-        static let supportMail: String = Bundle.main.object(forInfoDictionaryKey: "Notabene Support Mail") as? String ?? ""
+        static let identityProviderSupportMail: String = Bundle.main.object(forInfoDictionaryKey: "Notabene Support Mail") as? String ?? ""
+        static let concordiumSupportMail: String = Bundle.main.object(forInfoDictionaryKey: "Concordium Support Mail") as? String ?? ""
     }
 }

--- a/ioscommon/Commons/MailHelper.swift
+++ b/ioscommon/Commons/MailHelper.swift
@@ -13,7 +13,7 @@ struct MailHelper {
         return MFMailComposeViewController.canSendMail() || thirdPartyMailUrl(to: "", subject: "", body: "") != nil
     }
 
-    static func thirdPartyMailUrl(to: String, subject: String, body: String) -> URL? {
+    static func thirdPartyMailUrl(to: String, cc: String? = nil, subject: String, body: String) -> URL? {
         guard
             let subjectEncoded = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
             let bodyEncoded = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
@@ -21,10 +21,16 @@ struct MailHelper {
             return nil
         }
         
-        let gmailUrl = URL(string: "googlegmail://co?to=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)")
-        let outlookUrl = URL(string: "ms-outlook://compose?to=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)")
-        let yahooMail = URL(string: "ymail://mail/compose?to=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)")
-        let sparkUrl = URL(string: "readdle-spark://compose?recipient=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)")
+        var ccParams = ""
+        
+        if let carbonCopy = cc {
+            ccParams = "&cc=\(carbonCopy)"
+        }
+        
+        let gmailUrl = URL(string: "googlegmail://co?to=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)\(ccParams)")
+        let outlookUrl = URL(string: "ms-outlook://compose?to=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)\(ccParams)")
+        let yahooMail = URL(string: "ymail://mail/compose?to=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)\(ccParams)")
+        let sparkUrl = URL(string: "readdle-spark://compose?recipient=\(to)&subject=\(subjectEncoded)&body=\(bodyEncoded)\(ccParams)")
         
         if let gmailUrl = gmailUrl, UIApplication.shared.canOpenURL(gmailUrl) {
             return gmailUrl

--- a/ioscommon/Commons/SupportMailProtocol.swift
+++ b/ioscommon/Commons/SupportMailProtocol.swift
@@ -10,12 +10,29 @@ import MessageUI
 import UIKit
 
 protocol SupportMail: AnyObject {
-    func launchSupport(presenter: UIViewController, delegate: MFMailComposeViewControllerDelegate, recipient: String, subject: String, body: String)
+    func launchSupport(
+        presenter: UIViewController,
+        delegate: MFMailComposeViewControllerDelegate,
+        recipient: String,
+        ccRecipient: String?,
+        subject: String,
+        body: String
+    )
 }
 extension SupportMail {
-    func launchSupport(presenter: UIViewController, delegate: MFMailComposeViewControllerDelegate, recipient: String, subject: String, body: String) {
+    func launchSupport(
+        presenter: UIViewController,
+        delegate: MFMailComposeViewControllerDelegate,
+        recipient: String,
+        ccRecipient: String? = nil,
+        subject: String,
+        body: String
+    ) {
         if MFMailComposeViewController.canSendMail() {
             let mfMailComposeViewController = MFMailComposeViewController()
+            let ccRecipients = [ccRecipient].compactMap { $0 }
+            
+            mfMailComposeViewController.setCcRecipients(ccRecipients)
             mfMailComposeViewController.mailComposeDelegate = delegate
             mfMailComposeViewController.setToRecipients([recipient])
             mfMailComposeViewController.setSubject(subject)

--- a/ioscommon/Commons/SupportMailProtocol.swift
+++ b/ioscommon/Commons/SupportMailProtocol.swift
@@ -40,7 +40,7 @@ extension SupportMail {
             
             presenter.present(mfMailComposeViewController, animated: true)
             
-        } else if let emailUrl = MailHelper.thirdPartyMailUrl(to: recipient, subject: subject, body: body) {
+        } else if let emailUrl = MailHelper.thirdPartyMailUrl(to: recipient, cc: ccRecipient, subject: subject, body: body) {
             UIApplication.shared.open(emailUrl)
         }
     }


### PR DESCRIPTION
## Purpose

![IMG_7E28F2CDC4D7-1](https://user-images.githubusercontent.com/8437817/135626852-06ccd690-12cd-4ee7-b851-c637e40fa831.jpeg)

#65 

## Changes

- Updated texts on alert dialog shown during identity failure
- Now it's possible to include optional `CC` for both native and third-party mail composer
- Two new static vars in `AppSettings` - `appVersion` and `iOSVersion` 


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
