### PR TITLE
Handle partially valid memos

### DIFF
--- a/ConcordiumWallet/Model/Memo.swift
+++ b/ConcordiumWallet/Model/Memo.swift
@@ -42,14 +42,19 @@ struct Memo: MemoDataType {
     init?(hex: String?) {
         guard
             let hex = hex,
-            let data = Data(hex: hex)
+            let data = Data(hex: hex),
+            case .utf8String(let decodedValue) = try? CBOR.decode(data.bytes)
         else {
             return nil
         }
         
-        let bytes = data.bytes
-        guard case .utf8String(let value) = try? CBOR.decode(bytes) else { return nil }
-        self.displayValue = value
+        let decodedValueHex = Data(bytes: decodedValue.encode(), count: decodedValue.encode().count).hexDescription
+        
+        if decodedValueHex == hex {
+            self.displayValue = decodedValue
+        } else {
+            self.displayValue = hex
+        }
     }
 }
 

--- a/ConcordiumWallet/Views/AccountsView/AccountSubmitted/TransactionSubmittedPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountSubmitted/TransactionSubmittedPresenter.swift
@@ -26,8 +26,6 @@ class TransactionSubmittedViewModel {
         
         if let memo = Memo(hex: transfer.memo) {
             self.memoText = String(format: "sendFund.memo.text".localized, memo.displayValue)
-        } else {
-            self.memoText = transfer.memo
         }
         
         switch transfer.transferType {


### PR DESCRIPTION
## Purpose

![Screenshot 2021-10-12 at 13 59 11](https://user-images.githubusercontent.com/8437817/136953374-1c9081cb-3bae-41a2-941e-020039727ad4.png)



Handling partially valid memos (mentioned [here](#66)) by showing hex value instead of what appears to be partially decoded value.

Closes #66

## Changes

Re-encoding of hex value and then comparing the length to the actual hex. If the two values are equal we have a success if not we assign the original `hex` string as `displayValue`. 

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
