### PR TITLE
Fix missing shielded transfers with memo

### DIFF
--- a/ConcordiumWallet/Model/Memo.swift
+++ b/ConcordiumWallet/Model/Memo.swift
@@ -48,7 +48,6 @@ struct Memo: MemoDataType {
             return nil
         }
         
-        
         /// Since the SwiftCBOR cannot ensure that the entire input was decoded
         /// we double check it by comparing the hex value of a successfuly
         /// decoded hex which was yet again encoded and the original hex

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/TransactionsLoadingHandler.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/TransactionsLoadingHandler.swift
@@ -109,7 +109,8 @@ class TransactionsLoadingHandler {
                     // For balance type shielded, we only keep shielded transactions and the self transfers
                     if transaction.details.type != "encryptedAmountTransfer" &&
                         transaction.details.type != "transferToEncrypted" &&
-                        transaction.details.type != "transferToPublic"{
+                        transaction.details.type != "transferToPublic" &&
+                        transaction.details.type != "encryptedAmountTransferWithMemo" {
                         return false
                     }
                 }


### PR DESCRIPTION
## Purpose

|  Normal Balance  | Shielded Balance   |
|---|---|
| ![Screenshot 2021-10-14 at 11 00 23](https://user-images.githubusercontent.com/8437817/137295629-50f8b3ea-f66e-41d1-9832-1a65997277ab.png)  | ![Screenshot 2021-10-14 at 10 16 19](https://user-images.githubusercontent.com/8437817/137295636-121d46ee-3c27-429f-995a-2d496db077e0.png)  |

Closing #67 

## Changes

* Including transactions of type  `encryptedAmountTransferWithMemo` in the transaction list

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
