### PR TITLE
Notification on succesful new account 

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -4954,7 +4954,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -4986,7 +4986,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -391,3 +391,8 @@ idiss@concordium.software";
 "supportmail.body" = "Hi! My identity issuance failed.\n\nHere is my info:\n\nIssuance reference:\n%@\n\nMobile Wallet version:\n%@ (%@) \n\nPlatform:\n\niOS: %@";
 
 "copyreference.info.text" = "You can copy the reference below, and then contact Notabene at concordium-idiss@notabene.id \n\n Optional: Add Concordium as CC via idiss@concordium.software";
+
+"accountfinalized.alert.title" = "Your new account is ready!";
+"accountfinalized.alert.message" = "Your new account %@ has finalized, and is now ready for use.\n\nWe recommend keeping a back-up of all accounts. You can make one now below, or later via the More page.\n\nRemember to store your back-up securely.";
+"accountfinalized.alert.action.backup" = "Make back-up";
+

--- a/ConcordiumWallet/Service/StorageManager.swift
+++ b/ConcordiumWallet/Service/StorageManager.swift
@@ -64,6 +64,10 @@ protocol StorageManagerProtocol {
     func removeUnfinishedAccounts()
     func removeAccountsWithoutAddress()
     func removeUnfinishedAccountsAndRelatedIdentities()
+    
+    func getPendingAccountsAddresses() -> [String]
+    func storePendingAccount(with address: String)
+    func removePendingAccount(with address: String)
 }
 
 enum StorageError: Error {
@@ -432,5 +436,37 @@ class StorageManager: StorageManagerProtocol {
                 removeIdentity(identity)
             }
         }
+    }
+    
+    func getPendingAccountsAddresses() -> [String] {
+        let key = UserDefaultKeys.pendingAccount.rawValue
+
+        guard let pendingAccountsAddresses = UserDefaults.standard.stringArray(forKey: key) else {
+            return []
+        }
+        
+        return pendingAccountsAddresses
+    }
+    
+    func storePendingAccount(with address: String) {
+        let key = UserDefaultKeys.pendingAccount.rawValue
+        
+        if var pendingAccounts = UserDefaults.standard.stringArray(forKey: key) {
+            pendingAccounts.append(address)
+            UserDefaults.standard.set(pendingAccounts, forKey: key)
+        } else {
+            UserDefaults.standard.set([address], forKey: key)
+        }
+    }
+    
+    func removePendingAccount(with address: String) {
+        let key = UserDefaultKeys.pendingAccount.rawValue
+        
+        guard var pendingAccounts = UserDefaults.standard.stringArray(forKey: key) else {
+            return
+        }
+        
+        pendingAccounts.removeAll(where: { $0 == address })
+        UserDefaults.standard.set(pendingAccounts, forKey: key)
     }
 }

--- a/ConcordiumWallet/Service/StorageManager.swift
+++ b/ConcordiumWallet/Service/StorageManager.swift
@@ -250,6 +250,9 @@ class StorageManager: StorageManagerProtocol {
         guard let accountEntity = account as? AccountEntity else {
             return
         }
+        
+        removePendingAccount(with: accountEntity.address)
+
         try? realm.write {
             realm.delete(accountEntity)
         }

--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -16,6 +16,7 @@ enum UserDefaultKeys: String {
     case biometricsEnabled
     case passwordChangeInProgress
     case dontShowMemoAlertWarning
+    case pendingAccount
 }
 
 struct AppSettings {

--- a/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 concordium. All rights reserved.
 //
 
+import Combine
 import Foundation
 import UIKit
 
@@ -54,9 +55,25 @@ class AccountsCoordinator: Coordinator {
     }
     
     func showExport() {
-       ///
+        let vc = ExportFactory.create(with: ExportPresenter(
+            dependencyProvider: ServicesProvider.defaultProvider(),
+            requestPasswordDelegate: self,
+            delegate: self
+        ))
+        navigationController.pushViewController(vc, animated: true)
     }
     
+    private func showCreateExportPassword() -> AnyPublisher<String, Error> {
+        let selectExportPasswordCoordinator = CreateExportPasswordCoordinator(
+            navigationController: TransparentNavigationController(),
+            dependencyProvider: ServicesProvider.defaultProvider()
+        )
+        self.childCoordinators.append(selectExportPasswordCoordinator)
+        selectExportPasswordCoordinator.navigationController.modalPresentationStyle = .fullScreen
+        selectExportPasswordCoordinator.start()
+        navigationController.present(selectExportPasswordCoordinator.navigationController, animated: true)
+        return selectExportPasswordCoordinator.passwordPublisher.eraseToAnyPublisher()
+    }
 }
 
 extension AccountsCoordinator: AccountsPresenterDelegate {
@@ -109,6 +126,44 @@ extension AccountsCoordinator: AccountDetailsDelegate {
     }
 
     func accountRemoved() {
+        navigationController.popViewController(animated: true)
+    }
+}
+
+extension AccountsCoordinator: RequestPasswordDelegate { }
+
+extension AccountsCoordinator: ExportPresenterDelegate {
+    func createExportPassword() -> AnyPublisher<String, Error> {
+        let cleanup: (Result<String, Error>) -> Future<String, Error> = { [weak self] result in
+                    let future = Future<String, Error> { promise in
+                        self?.navigationController.dismiss(animated: true) {
+                            promise(result)
+                        }
+                        self?.childCoordinators.removeAll { coordinator in
+                            coordinator is CreateExportPasswordCoordinator
+                        }
+                    }
+                    return future
+                }
+        return showCreateExportPassword()
+                .flatMap { cleanup(.success($0)) }
+                .catch { cleanup(.failure($0)) }
+                .eraseToAnyPublisher()
+    }
+
+    func shareExportedFile(url: URL, completion: @escaping () -> Void) {
+        let vc = UIActivityViewController(activityItems: [url], applicationActivities: [])
+        vc.completionWithItemsHandler = { exportActivityType, completed, _, _ in
+            // exportActivityType == nil means that the user pressed the close button on the share sheet
+            if completed || exportActivityType == nil {
+                completion()
+                self.exportFinished()
+            }
+        }
+        self.navigationController.present(vc, animated: true)
+    }
+    
+    func exportFinished() {
         navigationController.popViewController(animated: true)
     }
 }

--- a/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
@@ -52,9 +52,18 @@ class AccountsCoordinator: Coordinator {
         childCoordinators.append(accountDetailsCoordinator)
         accountDetailsCoordinator.start()
     }
+    
+    func showExport() {
+       ///
+    }
+    
 }
 
 extension AccountsCoordinator: AccountsPresenterDelegate {
+    func didSelectMakeBackup() {
+        showExport()
+    }
+    
     func createNewAccount() {
         delegate?.createNewAccount()
     }

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -264,8 +264,6 @@ class AccountsPresenter: AccountsPresenterProtocol {
     
     private func markPendingAccountAsFinalized(account: AccountDataType) {
         dependencyProvider.storageManager().removePendingAccount(with: account.address)
-        print("🚀🚀🚀🚀🚀🚀🚀 FINALIZED \(account.address) 🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀")
-        //TODO: remove from pending also when it fails
         view?.showAccountFinalized(accountName: account.name ?? "")
     }
     

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -19,7 +19,6 @@ class AccountsFactory {
 }
 
 class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProtocol, ShowToast, SupportMail, ShowIdentityFailure {
-
     var presenter: AccountsPresenterProtocol?
     private weak var updateTimer: Timer?
     
@@ -199,6 +198,19 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
             .map { $0 == ShieldedAccountEncryptionStatus.decrypted }
         .assign(to: \.isHidden, on: lockView)
         .store(in: &cancellables)
+    }
+    
+    func showAccountFinalized(accountName: String) {
+        let alert = RecoverableAlert(
+            title: "accountfinalized.alert.title".localized,
+            message: String(format: "accountfinalized.alert.message".localized, accountName),
+            actionTitle: "accountfinalized.alert.action.backup".localized,
+            okButton: true
+        )
+        
+        showRecoverableAlert(alert) { [weak self] in
+            self?.presenter?.userSelectedMakeBackup()
+        }
     }
 
     func showIdentityFailed(reference: String, completion: @escaping () -> Void) {

--- a/ConcordiumWallet/Views/Widgets/IdentityBaseInfoWidgetPresenter.swift
+++ b/ConcordiumWallet/Views/Widgets/IdentityBaseInfoWidgetPresenter.swift
@@ -31,7 +31,7 @@ struct IdentityDetailsInfoViewModel {
             title: "identitySubmitted.alert.title".localized,
             message: "identitySubmitted.alert.message".localized,
             actionTitle: "ok".localized,
-            okButton: nil
+            okButton: false
         )
         
         switch identity.state {

--- a/ConcordiumWallet/Views/Widgets/IdentityBaseInfoWidgetPresenter.swift
+++ b/ConcordiumWallet/Views/Widgets/IdentityBaseInfoWidgetPresenter.swift
@@ -31,7 +31,7 @@ struct IdentityDetailsInfoViewModel {
             title: "identitySubmitted.alert.title".localized,
             message: "identitySubmitted.alert.message".localized,
             actionTitle: "ok".localized,
-            okButton: false
+            okButton: nil
         )
         
         switch identity.state {

--- a/ConcordiumWallet/Views/Widgets/IdentityBaseInfoWidgetPresenter.swift
+++ b/ConcordiumWallet/Views/Widgets/IdentityBaseInfoWidgetPresenter.swift
@@ -30,7 +30,8 @@ struct IdentityDetailsInfoViewModel {
         self.recoverableAlert = RecoverableAlert(
             title: "identitySubmitted.alert.title".localized,
             message: "identitySubmitted.alert.message".localized,
-            actionTitle: "ok".localized
+            actionTitle: "ok".localized,
+            okButton: false
         )
         
         switch identity.state {

--- a/ioscommon/Commons/ShowAlertProtocol.swift
+++ b/ioscommon/Commons/ShowAlertProtocol.swift
@@ -13,6 +13,7 @@ struct RecoverableAlert {
     let title: String?
     let message: String?
     let actionTitle: String?
+    let okButton: Bool?
 }
 
 protocol ShowAlert: AnyObject {
@@ -67,6 +68,11 @@ extension ShowAlert where Self: UIViewController {
         }
         
         alert.addAction(action)
+        
+        if recovarableAlert.okButton != nil {
+            let okAction = UIAlertAction(title: "ok".localized, style: .default)
+            alert.addAction(okAction)
+        }
         
         present(alert, animated: true)
     }
@@ -134,6 +140,11 @@ extension ShowAlert where Self: Coordinator {
         }
         
         alert.addAction(action)
+        
+        if recovarableAlert.okButton != nil {
+            let okAction = UIAlertAction(title: "ok".localized, style: .default)
+            alert.addAction(okAction)
+        }
         
         navigationController.present(alert, animated: true)
     }

--- a/ioscommon/Commons/ShowAlertProtocol.swift
+++ b/ioscommon/Commons/ShowAlertProtocol.swift
@@ -69,7 +69,7 @@ extension ShowAlert where Self: UIViewController {
         
         alert.addAction(action)
         
-        if recovarableAlert.okButton != nil {
+        if let okButton = recovarableAlert.okButton, okButton {
             let okAction = UIAlertAction(title: "ok".localized, style: .default)
             alert.addAction(okAction)
         }
@@ -141,7 +141,7 @@ extension ShowAlert where Self: Coordinator {
         
         alert.addAction(action)
         
-        if recovarableAlert.okButton != nil {
+        if let okButton = recovarableAlert.okButton, okButton {
             let okAction = UIAlertAction(title: "ok".localized, style: .default)
             alert.addAction(okAction)
         }


### PR DESCRIPTION
## Purpose

![Screenshot 2021-10-29 at 13 52 02](https://user-images.githubusercontent.com/8437817/139429878-4fe04a1a-58dc-4602-b49d-9b25700f650a.png)


Closes #79 

## Changes

- Saving pending accounts addresses in user preferences (that will allow showing the notification across app sessions)
- Checking regularly (on view did appear event) if the pending accounts are being finalized
- Show notification alert when an account is being finalized

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
