### PR TITLE
Keychain passwords should be copied while restoring backup

### DIFF
--- a/ioscommon/Base/KeychainWrapper.swift
+++ b/ioscommon/Base/KeychainWrapper.swift
@@ -144,7 +144,7 @@ struct KeychainWrapper {
 
         let access: SecAccessControl?
         if let password = password {
-            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, .applicationPassword, nil)
+            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlocked, .applicationPassword, nil)
 
             let localAuthenticationContext = LAContext()
             let theApplicationPassword = password.data(using: .utf8)
@@ -155,7 +155,7 @@ struct KeychainWrapper {
             query[kSecUseAuthenticationContext as String] = localAuthenticationContext
             #endif
         } else {
-            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, .biometryCurrentSet, nil)
+            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlocked, .biometryCurrentSet, nil)
         }
         query[kSecAttrAccessControl as String] = access as AnyObject?
 
@@ -176,7 +176,7 @@ struct KeychainWrapper {
 
         let access: SecAccessControl?
         if let password = password {
-            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, .applicationPassword, nil)
+            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlocked, .applicationPassword, nil)
 
             let localAuthenticationContext = LAContext()
             let theApplicationPassword = password.data(using: .utf8)
@@ -191,7 +191,7 @@ struct KeychainWrapper {
             let pwType = AppSettings.passwordType?.rawValue ?? PasswordType.passcode.rawValue
             localAuthenticationContext.localizedCancelTitle = "keychain.popup.button.enter\(pwType)".localized
             query[kSecUseAuthenticationContext as String] = localAuthenticationContext
-            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlockedThisDeviceOnly, .biometryCurrentSet, nil)
+            access = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenUnlocked, .biometryCurrentSet, nil)
         }
 
         query[kSecAttrAccessControl as String] = access as AnyObject?


### PR DESCRIPTION
## Purpose

Closes #78

## Changes

* Changed keychain properties from `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` to `kSecAttrAccessibleWhenUnlocked` which will allow restoring the passwords saved in the keychain over to a new device upon encrypted backup

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
