### PR TITLE
Finalized account alerts fixes 

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		06AEE69123F4064A00D14834 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AEE69023F4064A00D14834 /* BaseView.swift */; };
 		06AEE69323F4065800D14834 /* WidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AEE69223F4065800D14834 /* WidgetView.swift */; };
 		06D178A123F6D54900ABC904 /* BaseTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D178A023F6D54900ABC904 /* BaseTabBar.swift */; };
+		074917CF273C02900087225F /* AccountSubmissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074917CE273C02900087225F /* AccountSubmissionStatus.swift */; };
+		074917D0273C02900087225F /* AccountSubmissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074917CE273C02900087225F /* AccountSubmissionStatus.swift */; };
+		074917D1273C02900087225F /* AccountSubmissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074917CE273C02900087225F /* AccountSubmissionStatus.swift */; };
+		074917D2273C02900087225F /* AccountSubmissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074917CE273C02900087225F /* AccountSubmissionStatus.swift */; };
 		074C00A326FB12F20090F7FE /* AddMemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074C00A226FB12F20090F7FE /* AddMemoViewController.swift */; };
 		074C00A526FB1D2A0090F7FE /* AddMemoPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074C00A426FB1D2A0090F7FE /* AddMemoPresenter.swift */; };
 		07519F6D26FB23DE00F4E6E3 /* AddMemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074C00A226FB12F20090F7FE /* AddMemoViewController.swift */; };
@@ -1460,6 +1464,7 @@
 		06AEE69023F4064A00D14834 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		06AEE69223F4065800D14834 /* WidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetView.swift; sourceTree = "<group>"; };
 		06D178A023F6D54900ABC904 /* BaseTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTabBar.swift; sourceTree = "<group>"; };
+		074917CE273C02900087225F /* AccountSubmissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSubmissionStatus.swift; sourceTree = "<group>"; };
 		074C00A226FB12F20090F7FE /* AddMemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemoViewController.swift; sourceTree = "<group>"; };
 		074C00A426FB1D2A0090F7FE /* AddMemoPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMemoPresenter.swift; sourceTree = "<group>"; };
 		07519F7326FB5AAB00F4E6E3 /* Memo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
@@ -2558,6 +2563,7 @@
 			isa = PBXGroup;
 			children = (
 				5211BABA2502140C00EE1658 /* AccountBalanceTypeEnum.swift */,
+				074917CE273C02900087225F /* AccountSubmissionStatus.swift */,
 				64FD333925FF8A7C00563703 /* KeyList.swift */,
 				64FD334D25FF8F6D00563703 /* SchemeVerifyKey.swift */,
 				64FD33CA2602330B00563703 /* CredentialResponse.swift */,
@@ -3528,6 +3534,7 @@
 				644BB67325DFB4220086ED48 /* main.swift in Sources */,
 				7F48C13F244DCD0B00997684 /* BaseTabBar.swift in Sources */,
 				528EB73B255C1EB600010554 /* GettingStartedPresenter.swift in Sources */,
+				074917CF273C02900087225F /* AccountSubmissionStatus.swift in Sources */,
 				7F48C142244DCD0B00997684 /* IdentityRevokersWidgetViewController.swift in Sources */,
 				528EB74F255C320600010554 /* InitialAccountInfoPresenter.swift in Sources */,
 				7FA0AE982460479100B7673F /* WidgetButton.swift in Sources */,
@@ -4050,6 +4057,7 @@
 				7F85B78B246A9A7C00ED09B8 /* IdentitiesViewController.swift in Sources */,
 				7F85B78C246A9A7C00ED09B8 /* IdentitiesService.swift in Sources */,
 				7F85B78D246A9A7C00ED09B8 /* AppSettings.swift in Sources */,
+				074917D1273C02900087225F /* AccountSubmissionStatus.swift in Sources */,
 				7F85B78E246A9A7C00ED09B8 /* UIView+Additions.swift in Sources */,
 				7F85B78F246A9A7C00ED09B8 /* PasswordFieldViewController.swift in Sources */,
 				529531B8256BDE1B004CECE4 /* ReleaseScheduleEntity.swift in Sources */,
@@ -4377,6 +4385,7 @@
 				7F85B887246A9AB600ED09B8 /* IdentityConfirmedPresenter.swift in Sources */,
 				7F85B888246A9AB600ED09B8 /* IdentityConfirmedViewController.swift in Sources */,
 				7F85B889246A9AB600ED09B8 /* IdentitiesPresenter.swift in Sources */,
+				074917D2273C02900087225F /* AccountSubmissionStatus.swift in Sources */,
 				7F85B88A246A9AB600ED09B8 /* IdentitiesViewController.swift in Sources */,
 				7F85B88B246A9AB600ED09B8 /* IdentitiesService.swift in Sources */,
 				529531B9256BDE1B004CECE4 /* ReleaseScheduleEntity.swift in Sources */,
@@ -4746,6 +4755,7 @@
 				19C2E32CFA409D5BA9A50A60 /* ToastLabel.swift in Sources */,
 				19C2EA06B4E5D36103E1E8A5 /* Logger.swift in Sources */,
 				52055F822552B8F10071F7CA /* IdentityCardView.swift in Sources */,
+				074917D0273C02900087225F /* AccountSubmissionStatus.swift in Sources */,
 				19C2E3DFF7E9AE050F860AA1 /* SendFundPresenter.swift in Sources */,
 				19C2EB74069A5C18BE3E0A27 /* SendFundViewController.swift in Sources */,
 				19C2E960F1FF0455D336825B /* SelectRecipientPresenter.swift in Sources */,

--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -4964,7 +4964,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -4996,7 +4996,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";

--- a/ConcordiumWallet/Model/AccountSubmissionStatus.swift
+++ b/ConcordiumWallet/Model/AccountSubmissionStatus.swift
@@ -1,0 +1,14 @@
+//
+//  AccountSubmissionStatus.swift
+//  ConcordiumWallet
+//
+//  Created by Kristiyan Dobrev on 10/11/2021.
+//  Copyright © 2021 concordium. All rights reserved.
+//
+
+import Foundation
+
+struct AccountSubmissionStatus {
+    let status: SubmissionStatusEnum
+    let account: AccountDataType
+}

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -400,7 +400,10 @@ idiss@concordium.software";
 
 "copyreference.info.text" = "You can copy the reference below, and then contact Notabene at concordium-idiss@notabene.id \n\n Optional: Add Concordium as CC via idiss@concordium.software";
 
-"accountfinalized.alert.title" = "Your new account is ready!";
-"accountfinalized.alert.message" = "Your new account %@ has finalized, and is now ready for use.\n\nWe recommend keeping a back-up of all accounts. You can make one now below, or later via the More page.\n\nRemember to store your back-up securely.";
+
+"accountfinalized.single.alert.title" = "Your new account is ready!";
+"accountfinalized.single.alert.message" = "Your new account %@ has finalized, and is now ready for use.\n\nWe recommend keeping a back-up of all accounts. You can make one now below, or later via the More page.\n\nRemember to store your back-up securely.";
+"accountfinalized.multiple.alert.title" = "Your new accounts are ready!";
+"accountfinalized.multiple.alert.message" = "Your new accounts are now finalized, and ready for use.\n\nWe recommend keeping a back-up of all accounts. You can make one now below, or later via the More page.\n\nRemember to store your back-up securely.";
 "accountfinalized.alert.action.backup" = "Make back-up";
 

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -402,7 +402,7 @@ idiss@concordium.software";
 
 
 "accountfinalized.single.alert.title" = "Your new account is ready!";
-"accountfinalized.single.alert.message" = "Your new account %@ has finalized, and is now ready for use.\n\nWe recommend keeping a back-up of all accounts. You can make one now below, or later via the More page.\n\nRemember to store your back-up securely.";
+"accountfinalized.single.alert.message" = "Your new account %@ has been finalized, and is now ready for use.\n\nWe recommend keeping a back-up of all accounts. You can make one now below, or later via the More page.\n\nRemember to store your back-up securely.";
 "accountfinalized.multiple.alert.title" = "Your new accounts are ready!";
 "accountfinalized.multiple.alert.message" = "Your new accounts are now finalized, and ready for use.\n\nWe recommend keeping a back-up of all accounts. You can make one now below, or later via the More page.\n\nRemember to store your back-up securely.";
 "accountfinalized.alert.action.backup" = "Make back-up";

--- a/ConcordiumWallet/Service/StorageManager.swift
+++ b/ConcordiumWallet/Service/StorageManager.swift
@@ -452,11 +452,10 @@ class StorageManager: StorageManagerProtocol { // swiftlint:disable:this type_bo
     }
     
     func storePendingAccount(with address: String) {
-        guard !getPendingAccountsAddresses().contains(where: { $0 == address }) else { return }
-
         let key = UserDefaultKeys.pendingAccount.rawValue
-        
+
         if var pendingAccounts = UserDefaults.standard.stringArray(forKey: key) {
+            guard !pendingAccounts.contains(where: { $0 == address }) else { return }
             pendingAccounts.append(address)
             UserDefaults.standard.set(pendingAccounts, forKey: key)
         } else {

--- a/ConcordiumWallet/Service/StorageManager.swift
+++ b/ConcordiumWallet/Service/StorageManager.swift
@@ -452,6 +452,8 @@ class StorageManager: StorageManagerProtocol { // swiftlint:disable:this type_bo
     }
     
     func storePendingAccount(with address: String) {
+        guard !getPendingAccountsAddresses().contains(where: { $0 == address }) else { return }
+
         let key = UserDefaultKeys.pendingAccount.rawValue
         
         if var pendingAccounts = UserDefaults.standard.stringArray(forKey: key) {

--- a/ConcordiumWallet/StyledViews/NavigationController/TransparentNavigationController.swift
+++ b/ConcordiumWallet/StyledViews/NavigationController/TransparentNavigationController.swift
@@ -9,6 +9,15 @@ import UIKit
 
 class TransparentNavigationController: BaseNavigationController {
     override func viewDidLoad() {
+        setupTransparentNavigationControllerStyle()
+        view.backgroundColor = .clear
+        statusBarStyle = .lightContent
+    }
+
+}
+
+extension UINavigationController {
+    func setupTransparentNavigationControllerStyle() {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
         appearance.titleTextAttributes = [
@@ -18,9 +27,5 @@ class TransparentNavigationController: BaseNavigationController {
 
         navigationBar.standardAppearance = appearance
         navigationBar.scrollEdgeAppearance = appearance
-
-        view.backgroundColor = .clear
-        statusBarStyle = .lightContent
     }
-
 }

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -263,10 +263,11 @@ class AccountsPresenter: AccountsPresenterProtocol {
         Publishers.MergeMany(pendingAccountStatusRequests)
             .collect()
             .receive(on: DispatchQueue.main)
-            .sink(receiveError: { _ in },
-                  receiveValue: { [weak self] data in
-                self?.handleFinalizedAccountsIfNeeded(data)
-            })
+            .sink(
+                receiveError: { _ in },
+                receiveValue: { [weak self] data in
+                    self?.handleFinalizedAccountsIfNeeded(data)
+                })
             .store(in: &cancellables)
     }
 

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -245,19 +245,17 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
         presenter?.userPressedCreate()
     }
 
-    func showAccountFinalizedNotificationIfNeeded(_ state: FinalizedAccountsNotificationState) {
+    func showAccountFinalizedNotification(_ notification: FinalizedAccountsNotification) {
         let title: String
         let message: String
 
-        switch state {
+        switch notification {
         case .singleAccount(let accountName):
             title = "accountfinalized.single.alert.title".localized
             message = String(format: "accountfinalized.single.alert.message".localized, accountName)
         case .multiple:
             title = "accountfinalized.multiple.alert.title".localized
             message = "accountfinalized.multiple.alert.message".localized
-        default:
-            return
         }
 
         let alert = RecoverableAlert(

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -157,13 +157,6 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
             self.setupUI(state: $0)
         }.store(in: &cancellables)
 
-        viewModel.$finalizedAccountsNotificationState
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] state in
-                self?.showAccountFinalizedNotificationIfNeeded(state)
-            })
-            .store(in: &cancellables)
-
         viewModel.$accounts
             .receive(on: RunLoop.main)
             .sink {
@@ -252,7 +245,7 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
         presenter?.userPressedCreate()
     }
 
-    private func showAccountFinalizedNotificationIfNeeded(_ state: FinalizedAccountsNotificationState) {
+    func showAccountFinalizedNotificationIfNeeded(_ state: FinalizedAccountsNotificationState) {
         let title: String
         let message: String
 
@@ -274,8 +267,10 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
             okButton: true
         )
 
-        showRecoverableAlert(alert) { [weak self] in
-            self?.presenter?.userSelectedMakeBackup()
+        DispatchQueue.main.async { [weak self] in
+            self?.showRecoverableAlert(alert) { [weak self] in
+                self?.presenter?.userSelectedMakeBackup()
+            }
         }
     }
 }

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -160,30 +160,7 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
         viewModel.$finalizedAccountsNotificationState
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] state in
-                let title: String
-                let message: String
-
-                switch state {
-                case .singleAccount(let accountName):
-                    title = "accountfinalized.single.alert.title".localized
-                    message = String(format: "accountfinalized.single.alert.message".localized, accountName)
-                case .multiple:
-                    title = "accountfinalized.multiple.alert.title".localized
-                    message = "accountfinalized.multiple.alert.message".localized
-                default:
-                    return
-                }
-
-                let alert = RecoverableAlert(
-                    title: title,
-                    message: message,
-                    actionTitle: "accountfinalized.alert.action.backup".localized,
-                    okButton: true
-                )
-
-                self?.showRecoverableAlert(alert) { [weak self] in
-                    self?.presenter?.userSelectedMakeBackup()
-                }
+                self?.showAccountFinalizedNotificationIfNeeded(state)
             })
             .store(in: &cancellables)
 
@@ -273,6 +250,33 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
 
     @IBAction func createNewButtonPressed(_ sender: Any) {
         presenter?.userPressedCreate()
+    }
+
+    private func showAccountFinalizedNotificationIfNeeded(_ state: FinalizedAccountsNotificationState) {
+        let title: String
+        let message: String
+
+        switch state {
+        case .singleAccount(let accountName):
+            title = "accountfinalized.single.alert.title".localized
+            message = String(format: "accountfinalized.single.alert.message".localized, accountName)
+        case .multiple:
+            title = "accountfinalized.multiple.alert.title".localized
+            message = "accountfinalized.multiple.alert.message".localized
+        default:
+            return
+        }
+
+        let alert = RecoverableAlert(
+            title: title,
+            message: message,
+            actionTitle: "accountfinalized.alert.action.backup".localized,
+            okButton: true
+        )
+
+        showRecoverableAlert(alert) { [weak self] in
+            self?.presenter?.userSelectedMakeBackup()
+        }
     }
 }
 

--- a/ConcordiumWallet/Views/Login/LoginCoordinator.swift
+++ b/ConcordiumWallet/Views/Login/LoginCoordinator.swift
@@ -34,6 +34,7 @@ class LoginCoordinator: Coordinator {
 
     func showLogin() {
         let vc = EnterPasswordFactory.create(with: LoginPresenter(delegate: self, dependencyProvider: dependencyProvider))
+        navigationController.setupTransparentNavigationControllerStyle()
         navigationController.pushViewController(vc, animated: false)
     }
 

--- a/ConcordiumWallet/Views/Login/PasswordViews/EnterPasswordViewController.swift
+++ b/ConcordiumWallet/Views/Login/PasswordViews/EnterPasswordViewController.swift
@@ -168,6 +168,8 @@ class EnterPasswordViewController: BaseViewController, Storyboarded {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/ConcordiumWallet/Views/Login/RequestPasswordDelegate.swift
+++ b/ConcordiumWallet/Views/Login/RequestPasswordDelegate.swift
@@ -16,19 +16,19 @@ extension RequestPasswordDelegate where Self: Coordinator {
         var modalPasswordVCShown = false
 
         let enterPasswordController = EnterPasswordFactory.create(with: requestPasswordPresenter)
-        let enterPasswordTransperantController = TransparentNavigationController()
-        enterPasswordTransperantController.modalPresentationStyle = .fullScreen
-        enterPasswordTransperantController.viewControllers = [enterPasswordController]
+        let enterPasswordTransparantController = TransparentNavigationController()
+        enterPasswordTransparantController.modalPresentationStyle = .fullScreen
+        enterPasswordTransparantController.viewControllers = [enterPasswordController]
 
         requestPasswordPresenter.performBiometricLogin(fallback: { [weak self] in
-            self?.navigationController.present(enterPasswordTransperantController, animated: true)
+            self?.navigationController.present(enterPasswordTransparantController, animated: true)
             modalPasswordVCShown = true
         })
 
         let cleanup: (Result<String, Error>) -> Future<String, Error> = { result in
             let future = Future<String, Error> { promise in
                 if modalPasswordVCShown {
-                    enterPasswordTransperantController.dismiss(animated: true) {
+                    enterPasswordTransparantController.dismiss(animated: true) {
                         promise(result)
                     }
                 } else {

--- a/ConcordiumWallet/Views/Login/RequestPasswordDelegate.swift
+++ b/ConcordiumWallet/Views/Login/RequestPasswordDelegate.swift
@@ -16,19 +16,19 @@ extension RequestPasswordDelegate where Self: Coordinator {
         var modalPasswordVCShown = false
 
         let enterPasswordController = EnterPasswordFactory.create(with: requestPasswordPresenter)
-        let enterPasswordTransparantController = TransparentNavigationController()
-        enterPasswordTransparantController.modalPresentationStyle = .fullScreen
-        enterPasswordTransparantController.viewControllers = [enterPasswordController]
+        let enterPasswordTransparentController = TransparentNavigationController()
+        enterPasswordTransparentController.modalPresentationStyle = .fullScreen
+        enterPasswordTransparentController.viewControllers = [enterPasswordController]
 
         requestPasswordPresenter.performBiometricLogin(fallback: { [weak self] in
-            self?.navigationController.present(enterPasswordTransparantController, animated: true)
+            self?.navigationController.present(enterPasswordTransparentController, animated: true)
             modalPasswordVCShown = true
         })
 
         let cleanup: (Result<String, Error>) -> Future<String, Error> = { result in
             let future = Future<String, Error> { promise in
                 if modalPasswordVCShown {
-                    enterPasswordTransparantController.dismiss(animated: true) {
+                    enterPasswordTransparentController.dismiss(animated: true) {
                         promise(result)
                     }
                 } else {

--- a/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
@@ -78,7 +78,7 @@ class IdentityImporter {
             let account = AccountEntity()
             account.name = accountData.name
             account.submissionId = accountData.submissionId
-            account.transactionStatus = .received
+            account.transactionStatus = .finalized
             account.identity = relatedIdentity
             account.encryptedAccountData = try storageManager.storePrivateAccountKeys(accountData.accountKeys, pwHash: pwHash).get()
             account.address = accountData.address

--- a/ioscommon/Commons/UIViewController+Additions.swift
+++ b/ioscommon/Commons/UIViewController+Additions.swift
@@ -43,3 +43,9 @@ extension UIViewController {
         viewController.removeFromParent()
     }
 }
+
+extension UIViewController {
+    var isOnScreen: Bool {
+        return isViewLoaded && view.window != nil
+    }
+}


### PR DESCRIPTION
## Purpose

* Delivering batch notification when multiple accounts are finalized https://github.com/Concordium/concordium-reference-wallet-ios/issues/79#issuecomment-964864489

* Fix issue with the passcode's navbar color if the app locks during the identity/account creation process. 

|![Screenshot 2021-11-11 at 09 06 14](https://user-images.githubusercontent.com/8437817/141281599-7912d047-1049-4246-82ab-23eee2932ebe.png)|
|-|


## Changes

* Zipping all network requests for accounts statuses instead of firing them in a for loop
* `UIViewController` extension var for checking whether the controller is shown on screen or not. Particularly useful to decide whether or not to show finalized account notification 
* `AccountSubmissionStatus` wrapper model
* Set light preferred status bar style for pass code view (previously dark) 
* Apply transparent navbar appearance upon entering passcode view (otherwise it pick the parent navigation controller and it might become white like the screenshot above)
* 
## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
