### PR TITLE
Fix parsing the callback from the ID provider

### DIFF
--- a/ConcordiumWallet/Service/Network/ApiConstants.swift
+++ b/ConcordiumWallet/Service/Network/ApiConstants.swift
@@ -54,7 +54,9 @@ struct ApiConstants {
     /// Note that the pollUrl is NOT expected to be URL-encoded.
     static func parseCallbackUri(uri: URL) -> (identityCreationId: String, pollUrl: String)? {
         let identityCreationId = uri.absoluteURL.lastPathComponent
-        guard let pollUrl = uri.absoluteString.components(separatedBy: "#code_uri=").last else {
+        let uriComponents = uri.absoluteString.components(separatedBy: "#code_uri=")
+        guard uriComponents.count == 2,
+              let pollUrl = uriComponents.last else {
             return nil
         }
         return (identityCreationId, pollUrl)


### PR DESCRIPTION
## Purpose

When the identity provider experiences an error in the identity creation flow, it redirects the browser to the callback URL with a `#error=...` component instead of a `#code_uri=...` component. The current logic for parsing the URL spuriously succeeds in this case, since it does not correctly check that `#code_uri` actually occurs in the URL.

This PR implements a fix that will only succeed if the `#code_uri` component is set.

This addresses #100 and at least the most apparent cause of #107.

## Changes

Change `parseCallbackUri` to only succeed if there is just one `#code_uri=` component.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
