### PR TITLE
Debug logging

### DIFF
--- a/ioscommon/Commons/Logger.swift
+++ b/ioscommon/Commons/Logger.swift
@@ -25,11 +25,15 @@ class Logger {
     }
 
     static func debug(_ items: Any..., fileName: String = #file, line: Int = #line) {
-        logText(items, level: .debug, fileName: fileName, line: line)
+        #if DEBUG
+            logText(items, level: .debug, fileName: fileName, line: line)
+        #endif
     }
 
     static func debug(_ items: String, fileName: String = #file, line: Int = #line) {
-        logText(items, level: .debug, fileName: fileName, line: line)
+        #if DEBUG
+            logText(items, level: .debug, fileName: fileName, line: line)
+        #endif
     }
 
     static func info(_ items: Any..., fileName: String = #file, line: Int = #line) {


### PR DESCRIPTION
## Purpose

Currently calling `Logger.debug("Imported  \(importedObjects.value)")` will log also in production which shouldn't be the case.

## Changes

Check for `DEBUG` flag availability before logging


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
