### PR TITLE
Updated Realm to latest 10.19.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 def pods
   pod 'MaterialComponents/Tabs+TabBarView', '124.2.0'
-  pod 'RealmSwift', '10.7.6'
+  pod 'RealmSwift', '10.19.0'
   pod 'SwiftCBOR', '0.4.4'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,16 +15,16 @@ PODS:
     - MaterialComponents/Ripple
     - MDFInternationalization
   - MDFInternationalization (3.0.0)
-  - Realm (10.7.6):
-    - Realm/Headers (= 10.7.6)
-  - Realm/Headers (10.7.6)
-  - RealmSwift (10.7.6):
-    - Realm (= 10.7.6)
+  - Realm (10.19.0):
+    - Realm/Headers (= 10.19.0)
+  - Realm/Headers (10.19.0)
+  - RealmSwift (10.19.0):
+    - Realm (= 10.19.0)
   - SwiftCBOR (0.4.4)
 
 DEPENDENCIES:
   - "MaterialComponents/Tabs+TabBarView (= 124.2.0)"
-  - RealmSwift (= 10.7.6)
+  - RealmSwift (= 10.19.0)
   - SwiftCBOR (= 0.4.4)
 
 SPEC REPOS:
@@ -38,10 +38,10 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
   MDFInternationalization: d697c55307816222a55685c4ccb1044ffb030c12
-  Realm: ed860452717c8db8f4bf832b6807f7f2ce708839
-  RealmSwift: e31c4ddbcc42ac879313d656b86f9ca539f6f4f4
+  Realm: 869ab2a7e3bdfa6bf06d8723251539f504e6f602
+  RealmSwift: f1f51c4a02fe826e5cea623b5441992f06bdc942
   SwiftCBOR: ce5354ec8b660da2d6fc754462881119dbe1f963
 
-PODFILE CHECKSUM: b4625e8875339e9c00859af9cd4faa4ad5ff1085
+PODFILE CHECKSUM: 0a2adcd7d5eb6120b4b5a84778f2f8491f75c42e
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
## Purpose


Closes #103 


Crash info: 

```
Realm files of format version 22 is not supported by this version of Realm
```

Seems strange that it worked after bumping the Realm version to `10.19.0`. That means Realm has introduce backwards compatibility sometime in between. 

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
