### PR TITLE
Refreshed accounts list if the identity failure is shown on AccountsV…

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -4984,7 +4984,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5016,7 +5016,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5048,7 +5048,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5080,7 +5080,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5231,7 +5231,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";
@@ -5265,7 +5265,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -139,7 +139,7 @@ protocol AccountsPresenterDelegate: AnyObject {
 // MARK: View
 protocol AccountsViewProtocol: ShowAlert, Loadable {
     func bind(to viewModel: AccountsListViewModel)
-    func showIdentityFailed(identityProviderName: String, identityProviderSupport: String, reference: String, completion: @escaping () -> Void)
+    func showIdentityFailed(identityProviderName: String, identityProviderSupport: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void)
     func showAccountFinalizedNotification(_ notification: FinalizedAccountsNotification)
     var isOnScreen: Bool { get }
 }
@@ -330,8 +330,13 @@ class AccountsPresenter: AccountsPresenterProtocol {
                 let identityProviderSupportEmail = identity.identityProvider?.support ?? ""
                 view?.showIdentityFailed(identityProviderName: identityProviderName,
                                          identityProviderSupport: identityProviderSupportEmail,
-                                         reference: reference) { [weak self] in
-                    self?.delegate?.tryAgainIdentity()
+                                         reference: reference) { [weak self] chosenAlertOption in
+                    switch chosenAlertOption {
+                    case .tryAgain:
+                        self?.delegate?.tryAgainIdentity()
+                    case .support, .copy, .cancel:
+                        self?.refresh(showLoadingIndicator: false)
+                    }
                 }
                 break // we break here because if there are more accounts that failed, we want to show that later on
             }

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -205,7 +205,7 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
         .store(in: &cancellables)
     }
     
-    func showIdentityFailed(identityProviderName: String, identityProviderSupport: String, reference: String, completion: @escaping () -> Void) {
+    func showIdentityFailed(identityProviderName: String, identityProviderSupport: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void) {
         showIdentityFailureAlert(identityProviderName: identityProviderName,
                                  identityProviderSupportEmail: identityProviderSupport,
                                  reference: reference,

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
@@ -71,8 +71,14 @@ class IdentitiesPresenter: IdentityGeneralPresenter {
                 let identityProviderSupport = identity.identityProvider?.support ?? ""
                 view?.showIdentityFailed(identityProviderName: identityProviderName,
                                          identityProviderSupportEmail: identityProviderSupport,
-                                         reference: reference) { [weak self] in
-                    self?.delegate?.tryAgainIdentity()
+                                         reference: reference) { [weak self] chosenAlertOption in
+                    switch chosenAlertOption {
+                    case .tryAgain:
+                        self?.delegate?.tryAgainIdentity()
+                    case .support, .copy, .cancel:
+                        //no need to refresh because the identities are not updated
+                        break
+                    }
                 }
                 break // we break here because if there are more accounts that failed, we want to show that later on
             }

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
@@ -26,7 +26,7 @@ class IdentitiesFactory {
 protocol IdentitiesViewProtocol: ShowAlert {
     func showCreateIdentityView(show: Bool)
     func reloadView()
-    func showIdentityFailed(identityProviderName: String, identityProviderSupportEmail: String, reference: String, completion: @escaping () -> Void)
+    func showIdentityFailed(identityProviderName: String, identityProviderSupportEmail: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void)
 }
 
 class IdentitiesViewController: BaseViewController, Storyboarded, ShowToast, SupportMail, ShowIdentityFailure {
@@ -136,7 +136,7 @@ extension IdentitiesViewController: IdentitiesViewProtocol {
         tableView.reloadData()
     }
     
-    func showIdentityFailed(identityProviderName: String, identityProviderSupportEmail: String, reference: String, completion: @escaping () -> Void) {
+    func showIdentityFailed(identityProviderName: String, identityProviderSupportEmail: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void) {
         showIdentityFailureAlert(identityProviderName: identityProviderName,
                                  identityProviderSupportEmail: identityProviderSupportEmail,
                                  reference: reference,

--- a/ioscommon/Commons/ShowIdentityFailureProtocol.swift
+++ b/ioscommon/Commons/ShowIdentityFailureProtocol.swift
@@ -10,11 +10,18 @@ import Foundation
 import MessageUI
 import UIKit
 
+enum IdentityFailureAlertOption {
+    case tryAgain
+    case support
+    case copy
+    case cancel
+}
+
 protocol ShowIdentityFailure: AnyObject {
     func showIdentityFailureAlert(identityProviderName: String,
                                   identityProviderSupportEmail: String,
                                   reference: String,
-                                  completion: @escaping () -> Void)
+                                  completion: @escaping (_ result: IdentityFailureAlertOption) -> Void)
 }
 
 typealias IdentityFailableViewController = UIViewController & ShowToast & SupportMail & MFMailComposeViewControllerDelegate
@@ -23,7 +30,7 @@ extension ShowIdentityFailure where Self: IdentityFailableViewController {
     func showIdentityFailureAlert(identityProviderName: String,
                                   identityProviderSupportEmail: String,
                                   reference: String,
-                                  completion: @escaping () -> Void) {
+                                  completion: @escaping (_ result: IdentityFailureAlertOption) -> Void) {
         let concordiumSupportEmail = AppConstants.Support.concordiumSupportMail
         let alert = UIAlertController(
             title: "identityfailed.title".localized,
@@ -32,7 +39,7 @@ extension ShowIdentityFailure where Self: IdentityFailableViewController {
         )
         
         let tryAgainAction = UIAlertAction(title: "identityfailed.tryagain".localized, style: .default) { _ in
-            completion()
+            completion(.tryAgain)
         }
         
         alert.addAction(tryAgainAction)
@@ -57,6 +64,7 @@ extension ShowIdentityFailure where Self: IdentityFailableViewController {
                     subject: String(format: "supportmail.subject".localized, reference),
                     body: supportMailBody
                 )
+                completion(.support)
             }
             
             alert.message = String(format: "identityfailed.message".localized, identityProviderName)
@@ -72,10 +80,13 @@ extension ShowIdentityFailure where Self: IdentityFailableViewController {
                                    identityProviderName,
                                    identityProviderSupportEmail,
                                    concordiumSupportEmail)
+            completion(.copy)
             alert.addAction(copyAction)
         }
         
-        let cancelAction = UIAlertAction(title: "errorAlert.cancelButton".localized, style: .cancel)
+        let cancelAction = UIAlertAction(title: "errorAlert.cancelButton".localized, style: .cancel) { _ in
+            completion(.cancel)
+        }
         alert.addAction(cancelAction)
         
         present(alert, animated: true)

--- a/ioscommon/Commons/ShowIdentityFailureProtocol.swift
+++ b/ioscommon/Commons/ShowIdentityFailureProtocol.swift
@@ -74,13 +74,13 @@ extension ShowIdentityFailure where Self: IdentityFailableViewController {
             let copyAction = UIAlertAction(title: "identityfailed.copyreference".localized, style: .default) { [weak self] _ in
                 CopyPasterHelper.copy(string: supportMailBody)
                 self?.showToast(withMessage: "supportmail.copied".localized)
+                completion(.copy)
             }
             alert.message = String(format: "identityfailed.nomail.message".localized,
                                    identityProviderName,
                                    identityProviderName,
                                    identityProviderSupportEmail,
                                    concordiumSupportEmail)
-            completion(.copy)
             alert.addAction(copyAction)
         }
         


### PR DESCRIPTION
## Purpose

Fix crash when opening invalid account after identity is invalidated (Fixes #87 - last comments)
 
## Changes

- Added IdentityFailureAlertOption in order to get a callback in the presenter when other option besides 'Try again'  is selected. This allows us to refresh the list of accounts and avoid trying to open the details for an already removed account (which causes a crash)
- Bumped build no

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
