### PR TITLE
Removed optimisation for lookup as it was causing issues with aliases

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountTransactionsData/TransactionViewModel.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountTransactionsData/TransactionViewModel.swift
@@ -200,15 +200,9 @@ extension TransactionDetailsViewModel {
             transactionEvents = details.events
         }
 
-        let fromAddressName: String? =
-                OriginTypeEnum.typeSelf == transaction.origin?.type
-                        ? account.name
-                        : recipientListLookup(details.transferSource)
+        let fromAddressName: String? = recipientListLookup(details.transferSource)
 
-        let toAddressName: String? =
-                OriginTypeEnum.typeSelf == transaction.origin?.type
-                        ? recipientListLookup(details.transferDestination)
-                        : account.name
+        let toAddressName: String? = recipientListLookup(details.transferDestination)
 
         self.init(rejectReason: details.rejectReason,
                 origin: (originAddress),


### PR DESCRIPTION
## Purpose

Transactions sent/received by an alias where shown in the list with "main account" name instead of "alias account" name, when viewing from the "main account" of the alias. Fixes #127

## Changes

Both transferSource and transferDestination are now looked up in address book, no matter if the current account is the source or destination (instead of using the account name directly)

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
