### PR TITLE
Show backup banner warning only after new account is created

### DIFF
--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -18,7 +18,7 @@ enum UserDefaultKeys: String {
     case dontShowMemoAlertWarning
     case pendingAccount
     case acceptedTermsHash
-    case backupPerformed
+    case needsBackupWarning
 }
 
 struct AppSettings {
@@ -78,12 +78,12 @@ struct AppSettings {
         }
     }
 
-    static var backupPerformed: Bool {
+    static var needsBackupWarning: Bool {
         get {
-            UserDefaults.standard.bool(forKey: UserDefaultKeys.backupPerformed.rawValue)
+            UserDefaults.standard.bool(forKey: UserDefaultKeys.needsBackupWarning.rawValue)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.backupPerformed.rawValue)
+            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.needsBackupWarning.rawValue)
         }
     }
     

--- a/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
@@ -168,7 +168,7 @@ extension AccountsCoordinator: ExportPresenterDelegate {
         vc.completionWithItemsHandler = { exportActivityType, completed, _, _ in
             // exportActivityType == nil means that the user pressed the close button on the share sheet
             if completed {
-                AppSettings.backupPerformed = true
+                AppSettings.needsBackupWarning = false
             }
 
             if completed || exportActivityType == nil {

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -285,12 +285,12 @@ class AccountsPresenter: AccountsPresenterProtocol {
         }
 
         if finalizedAccounts.count > 1 {
-            AppSettings.backupPerformed = false
+            AppSettings.needsBackupWarning = true
             checkForBackup()
             view?.showAccountFinalizedNotification(.multiple)
             finalizedAccounts.forEach { markPendingAccountAsFinalized(account: $0) }
         } else if finalizedAccounts.count == 1, let account = finalizedAccounts.first {
-            AppSettings.backupPerformed = false
+            AppSettings.needsBackupWarning = true
             checkForBackup()
             view?.showAccountFinalizedNotification(.singleAccount(accountName: account.name ?? ""))
             markPendingAccountAsFinalized(account: account)
@@ -322,7 +322,7 @@ class AccountsPresenter: AccountsPresenterProtocol {
 
     private func checkForBackup() {
         let finalizedAccounts = dependencyProvider.storageManager().getAccounts().filter { $0.transactionStatus == .finalized }
-        let showWarning = finalizedAccounts.isEmpty ? false : !AppSettings.backupPerformed
+        let showWarning = finalizedAccounts.isEmpty ? false : AppSettings.needsBackupWarning
         view?.showBackupWarningBanner(showWarning)
     }
     


### PR DESCRIPTION
## Purpose

The backup warning should only be shown after new account is created.

## Changes

* Renamed `UserDefaultKey`  `backupPerformed`  to `needsBackupWarning` and inverted it's value. This way we make sure that the backup warning is not shown after a device restore  etc. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
