### PR TITLE
Backup fix

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -5006,7 +5006,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5039,7 +5039,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5072,7 +5072,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5105,7 +5105,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5257,7 +5257,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";
@@ -5292,7 +5292,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";

--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -413,6 +413,11 @@
 		5237188425753C4700B2BC31 /* MakeGenerateAaccountsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5237187E25753C4700B2BC31 /* MakeGenerateAaccountsRequest.swift */; };
 		5237188525753C4700B2BC31 /* MakeGenerateAaccountsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5237187E25753C4700B2BC31 /* MakeGenerateAaccountsRequest.swift */; };
 		5237188625753C4700B2BC31 /* MakeGenerateAaccountsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5237187E25753C4700B2BC31 /* MakeGenerateAaccountsRequest.swift */; };
+		5243C032278E2384005CAC8D /* SanityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5243C031278E2384005CAC8D /* SanityChecker.swift */; };
+		5243C033278E2384005CAC8D /* SanityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5243C031278E2384005CAC8D /* SanityChecker.swift */; };
+		5243C034278E2384005CAC8D /* SanityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5243C031278E2384005CAC8D /* SanityChecker.swift */; };
+		5243C035278E2384005CAC8D /* SanityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5243C031278E2384005CAC8D /* SanityChecker.swift */; };
+		5243C036278E2384005CAC8D /* SanityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5243C031278E2384005CAC8D /* SanityChecker.swift */; };
 		5248E7D7257A60F600E4F6EC /* BurgerMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248E7D6257A60F600E4F6EC /* BurgerMenuViewController.swift */; };
 		5248E7D8257A60F700E4F6EC /* BurgerMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248E7D6257A60F600E4F6EC /* BurgerMenuViewController.swift */; };
 		5248E7D9257A60F700E4F6EC /* BurgerMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248E7D6257A60F600E4F6EC /* BurgerMenuViewController.swift */; };
@@ -1635,6 +1640,7 @@
 		5237186A25751F2000B2BC31 /* 4.5.1.TX_lib_generate_accounts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 4.5.1.TX_lib_generate_accounts.json; sourceTree = "<group>"; };
 		5237187D25753C4700B2BC31 /* MakeGenerateAccountsResponseElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MakeGenerateAccountsResponseElement.swift; sourceTree = "<group>"; };
 		5237187E25753C4700B2BC31 /* MakeGenerateAaccountsRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MakeGenerateAaccountsRequest.swift; sourceTree = "<group>"; };
+		5243C031278E2384005CAC8D /* SanityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanityChecker.swift; sourceTree = "<group>"; };
 		5248E7D6257A60F600E4F6EC /* BurgerMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurgerMenuViewController.swift; sourceTree = "<group>"; };
 		5248E7DB257A611B00E4F6EC /* BurgerMenuPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurgerMenuPresenter.swift; sourceTree = "<group>"; };
 		52589B1625121E8F00ADD35B /* 4.4.1.TX_lib_decrypt_encrypted_amount.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 4.4.1.TX_lib_decrypt_encrypted_amount.json; sourceTree = "<group>"; };
@@ -2330,6 +2336,14 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		5243C030278E2360005CAC8D /* VerifyIdsAndAccounts */ = {
+			isa = PBXGroup;
+			children = (
+				5243C031278E2384005CAC8D /* SanityChecker.swift */,
+			);
+			path = VerifyIdsAndAccounts;
+			sourceTree = "<group>";
+		};
 		5248E7D5257A60DC00E4F6EC /* BurgerMenu */ = {
 			isa = PBXGroup;
 			children = (
@@ -2548,6 +2562,7 @@
 		7F85B8E02472D37600ED09B8 /* MoreSection */ = {
 			isa = PBXGroup;
 			children = (
+				5243C030278E2360005CAC8D /* VerifyIdsAndAccounts */,
 				642ED97025F21E2300A09BB3 /* Update */,
 				64DB66AC25DE636A00F4C605 /* About */,
 				7FB64A04247BC9FB00DC500E /* Export */,
@@ -3838,6 +3853,7 @@
 				19C2E94132B8C8B8853EB589 /* IdentityProviderEntity.swift in Sources */,
 				19C2ED92172857EAA39F101A /* RecipientEntity.swift in Sources */,
 				19C2E2CADC6C1C6CFCBBBA67 /* AccountEntity.swift in Sources */,
+				5243C032278E2384005CAC8D /* SanityChecker.swift in Sources */,
 				5211BAA724FD1D5100EE1658 /* Balance.swift in Sources */,
 				19C2EF5346654ECC2B83CB96 /* TransferEntity.swift in Sources */,
 				19C2E8375F25819B1599F588 /* DataStoreProtocol.swift in Sources */,
@@ -4065,6 +4081,7 @@
 				7F85B785246A9A7C00ED09B8 /* PrivateIDObjectData.swift in Sources */,
 				07519F7B26FB612700F4E6E3 /* UITextView+Extensions.swift in Sources */,
 				7F85B786246A9A7C00ED09B8 /* CreateIDRequest.swift in Sources */,
+				5243C034278E2384005CAC8D /* SanityChecker.swift in Sources */,
 				7F85B787246A9A7C00ED09B8 /* LetterSpacingLabel.swift in Sources */,
 				7F85B788246A9A7C00ED09B8 /* IdentityConfirmedPresenter.swift in Sources */,
 				52B2CE4B24F6806B0092F8EB /* ArsInfo.swift in Sources */,
@@ -4395,6 +4412,7 @@
 				7F85B880246A9AB600ED09B8 /* JSONSchemaSupport.swift in Sources */,
 				07519F7C26FB612700F4E6E3 /* UITextView+Extensions.swift in Sources */,
 				7F85B881246A9AB600ED09B8 /* AccountTransactionsDataPresenter.swift in Sources */,
+				5243C035278E2384005CAC8D /* SanityChecker.swift in Sources */,
 				7F85B882246A9AB600ED09B8 /* Metadata.swift in Sources */,
 				7F85B884246A9AB600ED09B8 /* PrivateIDObjectData.swift in Sources */,
 				52B2CE4C24F6806B0092F8EB /* ArsInfo.swift in Sources */,
@@ -4774,6 +4792,7 @@
 				19C2EC67C03A0297F505AE6C /* AccountAddressQRCoordinator.swift in Sources */,
 				19C2E32CFA409D5BA9A50A60 /* ToastLabel.swift in Sources */,
 				19C2EA06B4E5D36103E1E8A5 /* Logger.swift in Sources */,
+				5243C033278E2384005CAC8D /* SanityChecker.swift in Sources */,
 				52055F822552B8F10071F7CA /* IdentityCardView.swift in Sources */,
 				074917D0273C02900087225F /* AccountSubmissionStatus.swift in Sources */,
 				19C2E3DFF7E9AE050F860AA1 /* SendFundPresenter.swift in Sources */,
@@ -4863,6 +4882,7 @@
 				7F0573E724AC710C009517AD /* StorageManagerMockHelper.swift in Sources */,
 				7F0573EA24AC710C009517AD /* GTUTests.swift in Sources */,
 				7F0573ED24AC7173009517AD /* AttributesFormatterTests.swift in Sources */,
+				5243C036278E2384005CAC8D /* SanityChecker.swift in Sources */,
 				7F0573E824AC710C009517AD /* TransactionsServiceMockHelper.swift in Sources */,
 				7F0573EB24AC710C009517AD /* TransactionsLoadingHandlerTests.swift in Sources */,
 				19C2EF490E9CA00157B61071 /* EncryptionServiceTest.swift in Sources */,

--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -5006,7 +5006,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5039,7 +5039,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5072,7 +5072,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5105,7 +5105,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5257,7 +5257,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";
@@ -5292,7 +5292,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";

--- a/ConcordiumWallet/Model/Database/AccountEntity.swift
+++ b/ConcordiumWallet/Model/Database/AccountEntity.swift
@@ -58,7 +58,7 @@ protocol AccountDataType: DataStoreProtocol {
     func withUpdatedIdentity(identity: IdentityDataType) -> AccountDataType
     func withUpdatedStatus(status: SubmissionStatusEnum) -> AccountDataType
     func withTransferFilters(filters: TransferFilter) -> AccountDataType
-    func withMarkAsReadOnly(_ isReadOnly: Bool = true) -> AccountDataType
+    func withMarkAsReadOnly(_ isReadOnly: Bool) -> AccountDataType
 }
 
 extension AccountDataType {
@@ -117,11 +117,12 @@ extension AccountDataType {
         return self
     }
     
-    func withMarkAsReadOnly(_ isReadOnly: Bool = true) {
+    func withMarkAsReadOnly(_ isReadOnly: Bool) -> AccountDataType {
         _ = write {
             var pAccount = $0
             pAccount.isReadOnly = isReadOnly
         }
+        return self
     }
 }
 

--- a/ConcordiumWallet/Model/Database/AccountEntity.swift
+++ b/ConcordiumWallet/Model/Database/AccountEntity.swift
@@ -58,6 +58,7 @@ protocol AccountDataType: DataStoreProtocol {
     func withUpdatedIdentity(identity: IdentityDataType) -> AccountDataType
     func withUpdatedStatus(status: SubmissionStatusEnum) -> AccountDataType
     func withTransferFilters(filters: TransferFilter) -> AccountDataType
+    func withMarkAsReadOnly(_ isReadOnly: Bool = true) -> AccountDataType
 }
 
 extension AccountDataType {
@@ -114,6 +115,13 @@ extension AccountDataType {
             pAccount.transferFilters = filters
         }
         return self
+    }
+    
+    func withMarkAsReadOnly(_ isReadOnly: Bool = true) {
+        _ = write {
+            var pAccount = $0
+            pAccount.isReadOnly = isReadOnly
+        }
     }
 }
 

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -108,7 +108,7 @@ add_identity_data = "Reveal Identity Data";
 
 "gettingstarted.title" = "Getting started";
 "gettingstarted.subtitle" = "Are you new here?";
-"gettingstarted.details" = "If this is your first time using the Concordium blockchain, you must create an initial account. \n\nIIn case this is not your first time around, you must import existing accounts to get access to them.\n\nHow would you like to continue?";
+"gettingstarted.details" = "If this is your first time using the Concordium blockchain, you must create an initial account. \n\nIn case this is not your first time around, you must import existing accounts to get access to them.\n\nHow would you like to continue?";
 "gettingstarted.newaccount" = "I want to create my initial account";
 "gettingstarted.importaccount" = "I want to import existing accounts";
 

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -327,12 +327,23 @@ process on-chain.";
 "more.updatePasswordAndBiometrics.infoText" = "By pressing Continue, you will be guided through setting up a new passcode. You will also get the option of enabling biometrics, or to continue without them.";
 "more.validateIdsAndAccounts" = "Validate IDs and Accounts";
 "more.validateIdsAndAccount.warningTitle" = "⚠️ Warning ⚠️";
-"more.validateIdsAndAccount.unusableIdentitiesFound" = "The keys for the following identities and accounts could not be found. Without the keys the identities and accounts cannot function. How would you like to proceed?";
+"more.validateIdsAndAccount.unusableIdentitiesFound" = "The keys for the following identities and accounts could not be found. Without the keys the identities and accounts cannot function. How would you like to proceed?\n";
 "more.validateIdsAndAccount.removeFromApp" = "Remove from app";
 "more.validateIdsAndAccount.remindLater" = "Remind me later";
 "more.validateIdsAndAccount.keep" = "Keep as read-only";
 "more.validateIdsAndAccount.identity" = "\nIdentity: %@\n";
 "more.validateIdsAndAccount.account" = "Account: %@\n";
+"more.validateIdsAndAccount.import" = "Import from backup";
+"more.validateIdsAndAccount.simpleWarningTitle" = "Warning";
+"more.validateIdsAndAccount.idsWithFunctioningAccounts" = "The following keyless identities have accounts that still function. These identities will be kept, but can’t be used. If you make an export, these identites and related accounts will not be included.";
+"more.validateIdsAndAccount.okay" = "Okay";
+"more.validateIdsAndAccount.confirmationtitle" = "⚠️ Are you sure? ⚠️";
+"more.validateIdsAndAccount.yesremoveFromApp" = "Yes, remove from app";
+"more.validateIdsAndAccount.confirmationtext" = "If you remove the affected identities and accounts from the app and you don’t have a backup, they cannot be added again later.\n\n\n This action should only be done if you are absolutely sure you can’t recover them, and want them removed from your wallet.\n\n Do you still want to remove them?";
+"more.validateIdsAndAccount.allOk.title" = "Success";
+"more.validateIdsAndAccount.allOk.description" = "All your identities and accounts are valid and functional.";
+
+
 
 "more.about" = "About";
 "more.about.title" = "About";
@@ -379,6 +390,9 @@ process on-chain.";
 "revealattributes.details" = "You can choose to reveal a range of attributes on your account, e.g. your country of residence. Revealing attributes means that the information will be public on the Concordium blockchain, and that it cannot be hidden or deleted again. \n\n If you have no good reason for revealing attributes, we strongly recommend not revealing any.";
 "revealattributes.submitAccount" = "Submit account";
 "revealattributes.selectAttributes"= "Reveal account attributes";
+"identitymissingkeyserror.title" = "Missing keys";
+"identitymissingkeyserror.details" = "This identity does not have any keys, which means it cannot be used to create a new account.\n\nPlease choose another identity, or create a new one, to make a new account.";
+"identitymissingkeyserror.okay" = "Okay";
 
 "identityfailed.title" = "Identity issuance failed";
 "identityfailed.tryagain" = "Try again";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -59,6 +59,7 @@ add_identity_data = "Reveal Identity Data";
 "requestExportPassword.password.descriptiveText" = "Enter the export password created when exporting the file";
 "import.passwordError" = "Invalid password or import file corrupted";
 "import.environmentError" = "Files exported on Concordium Mainnet, TestNet or StageNet are not compatible with the other chains. Please import on the correct chain.";
+"import.noIdentitiesError" = "The file imported did not contain any identities. This indicates a corrupted backup file.";
 "import.noUserCreated" = "Please create password first. Then try again.";
 "import.importing.title" = "Importing...";
 "import.importing.subtitle" = "Please hold on a moment,\nwhile the import is finishing";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -325,6 +325,14 @@ process on-chain.";
 "more.update.button.continue" = "Continue";
 "more.update.error.nonFinalizedItems" = "All identities and accounts must be finalized before passcode can be changed. Please wait, then try again.";
 "more.updatePasswordAndBiometrics.infoText" = "By pressing Continue, you will be guided through setting up a new passcode. You will also get the option of enabling biometrics, or to continue without them.";
+"more.validateIdsAndAccounts" = "Validate IDs and Accounts";
+"more.validateIdsAndAccount.warningTitle" = "⚠️ Warning ⚠️";
+"more.validateIdsAndAccount.unusableIdentitiesFound" = "The keys for the following identities and accounts could not be found. Without the keys the identities and accounts cannot function. How would you like to proceed?";
+"more.validateIdsAndAccount.removeFromApp" = "Remove from app";
+"more.validateIdsAndAccount.remindLater" = "Remind me later";
+"more.validateIdsAndAccount.keep" = "Keep as read-only";
+"more.validateIdsAndAccount.identity" = "\nIdentity: %@\n";
+"more.validateIdsAndAccount.account" = "Account: %@\n";
 
 "more.about" = "About";
 "more.about.title" = "About";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -106,7 +106,7 @@ add_identity_data = "Reveal Identity Data";
 
 "gettingstarted.title" = "Getting started";
 "gettingstarted.subtitle" = "Are you new here?";
-"gettingstarted.details" = "If this is your first time using the Concordium blockchain, you must create an initial account. \n\nIn case this is not your first time around, you can also import already existing accounts.\n\nHow would you like to continue?";
+"gettingstarted.details" = "If this is your first time using the Concordium blockchain, you must create an initial account. \n\nIIn case this is not your first time around, you must import existing accounts to get access to them.\n\nHow would you like to continue?";
 "gettingstarted.newaccount" = "I want to create my initial account";
 "gettingstarted.importaccount" = "I want to import existing accounts";
 

--- a/ConcordiumWallet/Service/ErrorMapper.swift
+++ b/ConcordiumWallet/Service/ErrorMapper.swift
@@ -17,6 +17,7 @@ enum ViewError: Error {
     case duplicateRecipient(name: String)
     case exportUnfinalizedAccounts(unfinalizedAccountsNames: [String])
     case cameraAccessDeniedError
+    case identityMissingKeys
 }
 
 extension ViewError: LocalizedError {
@@ -48,6 +49,8 @@ extension ViewError: LocalizedError {
             return "export.unfinalizedAccounts".localized + unfinalizedAccountsNames.joined(separator: ", ")
         case .cameraAccessDeniedError:
             return "view.error.cameraAccessDenied".localized
+        case .identityMissingKeys:
+            return "identitymissingkeyserror.details".localized
         }
     }
 }

--- a/ConcordiumWallet/Service/MobileWallet.swift
+++ b/ConcordiumWallet/Service/MobileWallet.swift
@@ -364,12 +364,13 @@ class MobileWallet: MobileWalletProtocol {
     
     func verifyIdentitiesAndAccounts(pwHash: String) -> [(IdentityDataType, [AccountDataType])] {
         let invalidIdentities = storageManager.getIdentities().filter { identity in
-            if let key = identity.encryptedPrivateIdObjectData, let _ = try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()  {
+            if let key = identity.encryptedPrivateIdObjectData,
+                let _ = try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get() {
                 return true
             }
             return false
         }
-        var report:[(IdentityDataType, [AccountDataType])] = []
+        var report: [(IdentityDataType, [AccountDataType])] = []
         for identity in invalidIdentities {
             let invalidAccountNames = storageManager.getAccounts(for: identity).filter {
                 (try? verifyPasscode(for: $0, pwHash: pwHash).get()) == nil

--- a/ConcordiumWallet/Service/MobileWallet.swift
+++ b/ConcordiumWallet/Service/MobileWallet.swift
@@ -365,7 +365,7 @@ class MobileWallet: MobileWalletProtocol {
     func verifyIdentitiesAndAccounts(pwHash: String) -> [(IdentityDataType, [AccountDataType])] {
         let invalidIdentities = storageManager.getIdentities().filter { identity in
             if let key = identity.encryptedPrivateIdObjectData,
-                let _ = try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get() {
+                (try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()) == nil {
                 return true
             }
             return false
@@ -373,7 +373,10 @@ class MobileWallet: MobileWalletProtocol {
         var report: [(IdentityDataType, [AccountDataType])] = []
         for identity in invalidIdentities {
             let invalidAccountNames = storageManager.getAccounts(for: identity).filter {
-                (try? verifyPasscode(for: $0, pwHash: pwHash).get()) == nil
+                if $0.isReadOnly {
+                    return false
+                }
+                return (try? verifyPasscode(for: $0, pwHash: pwHash).get()) == nil
             }
             report.append((identity, invalidAccountNames))
         }

--- a/ConcordiumWallet/Service/MobileWallet.swift
+++ b/ConcordiumWallet/Service/MobileWallet.swift
@@ -373,9 +373,6 @@ class MobileWallet: MobileWalletProtocol {
         var report: [(IdentityDataType, [AccountDataType])] = []
         for identity in invalidIdentities {
             let invalidAccountNames = storageManager.getAccounts(for: identity).filter {
-                if $0.isReadOnly {
-                    return false
-                }
                 return (try? verifyPasscode(for: $0, pwHash: pwHash).get()) == nil
             }
             report.append((identity, invalidAccountNames))

--- a/ConcordiumWallet/Service/ServicesProvider.swift
+++ b/ConcordiumWallet/Service/ServicesProvider.swift
@@ -25,7 +25,7 @@ protocol MoreFlowCoordinatorDependencyProvider: WalletAndStorageDependencyProvid
     func keychainWrapper() -> KeychainWrapperProtocol
 }
 
-protocol LoginDependencyProvider {
+protocol LoginDependencyProvider: WalletAndStorageDependencyProvider {
     func keychainWrapper() -> KeychainWrapperProtocol
 }
 

--- a/ConcordiumWallet/Service/StorageManager.swift
+++ b/ConcordiumWallet/Service/StorageManager.swift
@@ -480,7 +480,6 @@ class StorageManager: StorageManagerProtocol { // swiftlint:disable:this type_bo
         var documentsDirectoryURL = documentsPaths[0]
         excludeFromBackup(url: &documentsDirectoryURL)
         
-        
         let libraryPaths = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
         var libraryURL = libraryPaths[0]
         excludeFromBackup(url: &libraryURL)

--- a/ConcordiumWallet/Service/StorageManager.swift
+++ b/ConcordiumWallet/Service/StorageManager.swift
@@ -83,6 +83,7 @@ class StorageManager: StorageManagerProtocol { // swiftlint:disable:this type_bo
     init(keychain: KeychainWrapperProtocol) {
         self.keychain = keychain
         Logger.debug("Initialized Realm database at \(realm.configuration.fileURL?.absoluteString ?? "")")
+        excludeDocumentsAndLibraryFoldersFromBackup()
     }
 
     // MARK: Identity
@@ -472,5 +473,27 @@ class StorageManager: StorageManagerProtocol { // swiftlint:disable:this type_bo
         
         pendingAccounts.removeAll(where: { $0 == address })
         UserDefaults.standard.set(pendingAccounts, forKey: key)
+    }
+    
+    private func excludeDocumentsAndLibraryFoldersFromBackup() {
+        let documentsPaths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        var documentsDirectoryURL = documentsPaths[0]
+        excludeFromBackup(url: &documentsDirectoryURL)
+        
+        
+        let libraryPaths = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
+        var libraryURL = libraryPaths[0]
+        excludeFromBackup(url: &libraryURL)
+        
+    }
+    
+    private func excludeFromBackup(url:inout URL) {
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        do {
+            try url.setResourceValues(values)
+        } catch let error {
+            Logger.debug("Unable to exclude folder from backup due to error: \(error)")
+        }
     }
 }

--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -18,6 +18,7 @@ enum UserDefaultKeys: String {
     case dontShowMemoAlertWarning
     case pendingAccount
     case acceptedTermsHash
+    case ignoreMissingKeysForIdsOrAccountsAtLogin
 }
 
 struct AppSettings {
@@ -74,6 +75,15 @@ struct AppSettings {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.acceptedTermsHash.rawValue)
+        }
+    }
+    
+    static var ignoreMissingKeysForIdsOrAccountsAtLogin: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaultKeys.ignoreMissingKeysForIdsOrAccountsAtLogin.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.ignoreMissingKeysForIdsOrAccountsAtLogin.rawValue)
         }
     }
     

--- a/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
@@ -32,7 +32,7 @@ class AccountsCoordinator: Coordinator {
     func start() {
         let vc = AccountsFactory.create(with: AccountsPresenter(dependencyProvider: dependencyProvider, delegate: self))
         vc.tabBarItem = UITabBarItem(title: "accounts_tab_title".localized, image: UIImage(named: "tab_bar_accounts_icon"), tag: 0)
-        navigationController.pushViewController(vc, animated: false)
+        navigationController.viewControllers = [vc]
     }
 
     func showCreateNewAccount(withDefaultValuesFrom account: AccountDataType? = nil) {

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -139,7 +139,10 @@ protocol AccountsPresenterDelegate: AnyObject {
 // MARK: View
 protocol AccountsViewProtocol: ShowAlert, Loadable {
     func bind(to viewModel: AccountsListViewModel)
-    func showIdentityFailed(identityProviderName: String, identityProviderSupport: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void)
+    func showIdentityFailed(identityProviderName: String,
+                            identityProviderSupport: String,
+                            reference: String,
+                            completion: @escaping (_ option: IdentityFailureAlertOption) -> Void)
     func showAccountFinalizedNotification(_ notification: FinalizedAccountsNotification)
     var isOnScreen: Bool { get }
 }

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -53,7 +53,6 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
         presenter?.viewDidLoad()
 
         dataSource = UITableViewDiffableDataSource<String, AccountViewModel>(tableView: tableView, cellProvider: createCell)
-//        tableView.applyConcordiumEdgeStyle()
         tableView.layer.masksToBounds = false
         tableView.backgroundColor = .white
         dataSource?.defaultRowAnimation = .none
@@ -224,7 +223,10 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
         .store(in: &cancellables)
     }
     
-    func showIdentityFailed(identityProviderName: String, identityProviderSupport: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void) {
+    func showIdentityFailed(identityProviderName: String,
+                            identityProviderSupport: String,
+                            reference: String,
+                            completion: @escaping (_ option: IdentityFailureAlertOption) -> Void) {
         showIdentityFailureAlert(identityProviderName: identityProviderName,
                                  identityProviderSupportEmail: identityProviderSupport,
                                  reference: reference,
@@ -254,7 +256,6 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
             createNewButton.isHidden = true
             shouldShowAddAccountButtonInTopBar = true
         }
-
         if shouldShowAddAccountButtonInTopBar {
             let rightButtonImage = UIImage(named: "add_icon")
             navigationItem.rightBarButtonItem = UIBarButtonItem(image: rightButtonImage,

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -17,7 +17,7 @@ class AccountsFactory {
         }
     }
 }
-
+// swiftlint:disable:next type_body_length
 class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProtocol, ShowToast, SupportMail, ShowIdentityFailure {
     var presenter: AccountsPresenterProtocol?
     private weak var updateTimer: Timer?

--- a/ConcordiumWallet/Views/AccountsView/CreateAccount/RevealAttributesPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/CreateAccount/RevealAttributesPresenter.swift
@@ -72,6 +72,12 @@ class RevealAttributesPresenter: RevealAttributesPresenterProtocol {
                     return
                 } else if let viewError = error as? ViewError {
                     self?.view?.showErrorAlert(viewError)
+                } else if case KeychainError.itemNotFound = error {
+                    let recoverableAlert = RecoverableAlert(title: "identitymissingkeyserror.title".localized,
+                                                            message: "identitymissingkeyserror.details".localized,
+                                                            actionTitle: "identitymissingkeyserror.okay".localized,
+                                                            okButton: nil)
+                    self?.view?.showRecoverableAlert(recoverableAlert, completion: {})
                 } else {
                      self?.view?.showErrorAlert(ErrorMapper.toViewError(error: error))
                 }

--- a/ConcordiumWallet/Views/Identities/IdentitiesCoordinator.swift
+++ b/ConcordiumWallet/Views/Identities/IdentitiesCoordinator.swift
@@ -83,7 +83,8 @@ class IdentitiesCoordinator: Coordinator {
                 let identityProviderName = identity.identityProviderName ?? ""
                 //if no ip support email is present, we use Concordium's
                 let identityProviderSupportEmail = identity.identityProvider?.support ?? AppConstants.Support.concordiumSupportMail
-                let copyReferenceInfoWidgetPresenter = CopyReferenceInfoWidgetPresenter(identityProviderName: identityProviderName, identityProviderSupportEmail: identityProviderSupportEmail)
+                let copyReferenceInfoWidgetPresenter = CopyReferenceInfoWidgetPresenter(identityProviderName: identityProviderName,
+                                                                                        identityProviderSupportEmail: identityProviderSupportEmail)
                 vc.primaryCenterWidget = CopyReferenceInfoWidgetFactory.create(with: copyReferenceInfoWidgetPresenter)
             }
             

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesViewController.swift
@@ -26,7 +26,10 @@ class IdentitiesFactory {
 protocol IdentitiesViewProtocol: ShowAlert {
     func showCreateIdentityView(show: Bool)
     func reloadView()
-    func showIdentityFailed(identityProviderName: String, identityProviderSupportEmail: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void)
+    func showIdentityFailed(identityProviderName: String,
+                            identityProviderSupportEmail: String,
+                            reference: String,
+                            completion: @escaping (_ option: IdentityFailureAlertOption) -> Void)
 }
 
 class IdentitiesViewController: BaseViewController, Storyboarded, ShowToast, SupportMail, ShowIdentityFailure {
@@ -155,7 +158,10 @@ extension IdentitiesViewController: IdentitiesViewProtocol {
         tableView.reloadData()
     }
     
-    func showIdentityFailed(identityProviderName: String, identityProviderSupportEmail: String, reference: String, completion: @escaping (_ option: IdentityFailureAlertOption) -> Void) {
+    func showIdentityFailed(identityProviderName: String,
+                            identityProviderSupportEmail: String,
+                            reference: String,
+                            completion: @escaping (_ option: IdentityFailureAlertOption) -> Void) {
         showIdentityFailureAlert(identityProviderName: identityProviderName,
                                  identityProviderSupportEmail: identityProviderSupportEmail,
                                  reference: reference,

--- a/ConcordiumWallet/Views/Login/PasswordViews/EnterPasswordViewController.swift
+++ b/ConcordiumWallet/Views/Login/PasswordViews/EnterPasswordViewController.swift
@@ -26,7 +26,7 @@ class EnterPasswordFactory {
 }
 
 // MARK: View -
-protocol EnterPasswordViewProtocol: AnyObject {
+protocol EnterPasswordViewProtocol: ShowAlert {
     var pincodeDelegate: PasscodeFieldDelegate? { get set }
     func showKeyboard()
     func setState(_: PasswordSelectionState, newPasswordFieldDelegate: PasswordFieldDelegate & PasscodeFieldDelegate, animated: Bool, reverse: Bool)

--- a/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
+++ b/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
@@ -42,7 +42,7 @@ class LoginPresenter: EnterPasswordPresenterProtocol {
                 .onSuccess { pwHash in
                     let passwordCheck = dependencyProvider.keychainWrapper()
                             .checkPasswordHash(pwHash: pwHash)
-                    _ = sanityChecker.getSanityReport(pwHash: pwHash) //we just make the sanitary report
+                    _ = sanityChecker.generateSanityReport(pwHash: pwHash) //we just make the sanitary report
                     handlePasswordCheck(checkPassword: passwordCheck)
                 }
         }
@@ -57,7 +57,7 @@ class LoginPresenter: EnterPasswordPresenterProtocol {
     func passwordEntered(password: String) {
         let passwordCheck = dependencyProvider.keychainWrapper()
                 .checkPassword(password: password)
-        _  = sanityChecker.getSanityReport(pwHash: dependencyProvider.keychainWrapper().hashPassword(password))
+        _  = sanityChecker.generateSanityReport(pwHash: dependencyProvider.keychainWrapper().hashPassword(password))
         handlePasswordCheck(checkPassword: passwordCheck)
     }
 

--- a/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
+++ b/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
@@ -18,10 +18,12 @@ class LoginPresenter: EnterPasswordPresenterProtocol {
     weak var delegate: LoginViewDelegate?
     let dependencyProvider: LoginDependencyProvider
     let viewState: PasswordSelectionState = AppSettings.passwordType == .password ? .loginWithPassword : .loginWithPasscode
-
+    let sanityChecker: SanityChecker
+    
     init(delegate: LoginViewDelegate, dependencyProvider: LoginDependencyProvider) {
         self.delegate = delegate
         self.dependencyProvider = dependencyProvider
+//        self.sanityChecker = SanityChecker(requestPasswordDelegate: self, keychainWrapper: dependencyProvider.keychainWrapper(), mobileWallet: dependencyProvider.mobileWrapper(), storageManager: dependencyProvider.storageManager(), errorDisplayer: <#T##ShowAlert#>, coordinator: <#T##Coordinator#>)
     }
 
     func viewDidLoad() {

--- a/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
+++ b/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
@@ -18,7 +18,7 @@ class LoginPresenter: EnterPasswordPresenterProtocol {
     weak var delegate: LoginViewDelegate?
     let dependencyProvider: LoginDependencyProvider
     let viewState: PasswordSelectionState = AppSettings.passwordType == .password ? .loginWithPassword : .loginWithPasscode
-    let sanityChecker: SanityChecker
+//    let sanityChecker: SanityChecker
     
     init(delegate: LoginViewDelegate, dependencyProvider: LoginDependencyProvider) {
         self.delegate = delegate

--- a/ConcordiumWallet/Views/Login/PasswordViews/RequestExportPasswordPresenter.swift
+++ b/ConcordiumWallet/Views/Login/PasswordViews/RequestExportPasswordPresenter.swift
@@ -48,6 +48,8 @@ class RequestExportPasswordPresenter: EnterPasswordPresenterProtocol {
             delegate?.finishedEnteringPassword(password: password)
         } catch ImportError.unsupportedEnvironemt(_) {
             view?.showError("import.environmentError".localized)
+        } catch ImportError.missingIdentitiesError {
+            view?.showError("import.noIdentitiesError".localized)
         } catch {
             view?.showError("import.passwordError".localized)
         }

--- a/ConcordiumWallet/Views/MoreSection/Export/ExportService.swift
+++ b/ConcordiumWallet/Views/MoreSection/Export/ExportService.swift
@@ -10,6 +10,7 @@ enum ImportError: Error {
     case unsupportedVersion(inputVersion: Int)
     case unsupportedWalletType(type: String)
     case unsupportedEnvironemt(environment: String)
+    case missingIdentitiesError
 }
 
 struct ExportService {

--- a/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
@@ -23,7 +23,8 @@ class IdentityImporter {
                 //Here we have an identity stored.
                 //We check whether the identity has its keys and if it does, we try to
                 //import its accounts and mark it as duplicate in the report
-                if let key = existingEntity.encryptedPrivateIdObjectData, let _ = try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get() {
+                if let key = existingEntity.encryptedPrivateIdObjectData,
+                    let _ = try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get() {
                     importAccounts(identityData: identityDataToImport, identityEntity: existingEntity, pwHash: pwHash)
                     importReadOnlyAccounts(readOnlyAccounts, identityEntity: existingEntity, pwHash: pwHash)
                     importReport.duplicateIdentities.append(importedIdentity)
@@ -75,12 +76,13 @@ class IdentityImporter {
         
         let existingAccount = storageManager.getAccount(withAddress: accountData.address)
         let accountContainsKeys: Bool
-        if let storredAccount = existingAccount, let key = storredAccount.encryptedPrivateKey, let _ = try? storageManager.getPrivateAccountKeys(key: key, pwHash: pwHash).get() {
+        if let storredAccount = existingAccount,
+            let key = storredAccount.encryptedPrivateKey,
+            let _ = try? storageManager.getPrivateAccountKeys(key: key, pwHash: pwHash).get() {
             accountContainsKeys = true
         } else {
             accountContainsKeys = false
         }
-        
         
         // we allow overwritting if the account is readonly or it doesn't contain keys
         guard existingAccount?.isReadOnly == true || !accountContainsKeys else {

--- a/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
@@ -20,17 +20,27 @@ class IdentityImporter {
                         importReport: inout ImportedItemsReport) -> IdentityDataType? {
         do {
             if let existingEntity = storageManager.getIdentity(matching: identityDataToImport.identityObject) {
-                importAccounts(identityData: identityDataToImport, identityEntity: existingEntity, pwHash: pwHash)
-                importReadOnlyAccounts(readOnlyAccounts, identityEntity: existingEntity, pwHash: pwHash)
-                importReport.duplicateIdentities.append(importedIdentity)
-                return existingEntity
-            } else {
-                let identityEntity = try storeIdentityInDb(identityDataToImport, pwHash: pwHash)
-                importAccounts(identityData: identityDataToImport, identityEntity: identityEntity, pwHash: pwHash)
-                importReadOnlyAccounts(readOnlyAccounts, identityEntity: identityEntity, pwHash: pwHash)
-                importReport.importedIdentities.append(importedIdentity)
-                return identityEntity
+                //Here we have an identity stored.
+                //We check whether the identity has its keys and if it does, we try to
+                //import its accounts and mark it as duplicate in the report
+                if let key = existingEntity.encryptedPrivateIdObjectData, let _ = try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get() {
+                    importAccounts(identityData: identityDataToImport, identityEntity: existingEntity, pwHash: pwHash)
+                    importReadOnlyAccounts(readOnlyAccounts, identityEntity: existingEntity, pwHash: pwHash)
+                    importReport.duplicateIdentities.append(importedIdentity)
+                    return existingEntity
+                } else {
+                    //we delete the stored unusable identity
+                    storageManager.removeIdentity(existingEntity)
+                }
             }
+            // if we are here, we need to import the identity, either because there is no
+            // local copy or the local copy didn't contain keys
+            let identityEntity = try storeIdentityInDb(identityDataToImport, pwHash: pwHash)
+            importAccounts(identityData: identityDataToImport, identityEntity: identityEntity, pwHash: pwHash)
+            importReadOnlyAccounts(readOnlyAccounts, identityEntity: identityEntity, pwHash: pwHash)
+            importReport.importedIdentities.append(importedIdentity)
+            return identityEntity
+            
         } catch {
             importReport.failedIdentities.append(importedIdentity.name)
         }
@@ -64,14 +74,23 @@ class IdentityImporter {
     private func importAccount(_ accountData: ExportAccount, relatedIdentity: IdentityDataType, pwHash: String) {
         
         let existingAccount = storageManager.getAccount(withAddress: accountData.address)
+        let accountContainsKeys: Bool
+        if let storredAccount = existingAccount, let key = storredAccount.encryptedPrivateKey, let _ = try? storageManager.getPrivateAccountKeys(key: key, pwHash: pwHash).get() {
+            accountContainsKeys = true
+        } else {
+            accountContainsKeys = false
+        }
         
-        // we allow overwritting
-        guard existingAccount == nil || existingAccount?.isReadOnly == true else {
+        
+        // we allow overwritting if the account is readonly or it doesn't contain keys
+        guard existingAccount?.isReadOnly == true || !accountContainsKeys else {
             importedIdentity.duplicateAccounts.append(accountData.name)
             return
         }
+        
         // we remove the readonly account if it exists
-        // (we ony get here if we have a readonly account or existing account is nil)
+        // (we ony get here if we have a readonly account or
+        // existing account is nil or doesn't contain keys)
         storageManager.removeAccount(account: existingAccount)
         
         do {
@@ -103,7 +122,7 @@ class IdentityImporter {
     private func importReadOnlyAccount(_ readOnlyAccount: MakeGenerateAccountsResponseElement, relatedIdentity: IdentityDataType, pwHash: String) {
         let existingAccount = storageManager.getAccount(withAddress: readOnlyAccount.accountAddress)
         guard existingAccount == nil else {
-//            importedIdentity.duplicateAccounts.append(existingAccount?.name ?? "")
+            //we don't import a read-only account if the account is already saved locally
             return
         }
         do {

--- a/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
@@ -76,15 +76,15 @@ class IdentityImporter {
     private func importAccount(_ accountData: ExportAccount, relatedIdentity: IdentityDataType, pwHash: String) {
         let existingAccount = storageManager.getAccount(withAddress: accountData.address)
         let accountContainsKeys: Bool
-        if let storredAccount = existingAccount,
-            let key = storredAccount.encryptedPrivateKey,
+        if let storedAccount = existingAccount,
+            let key = storedAccount.encryptedPrivateKey,
            (try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()) == nil {
             accountContainsKeys = true
         } else {
             accountContainsKeys = false
         }
         
-        // we allow overwritting if the account is readonly or it doesn't contain keys
+        // we allow overwriting if the account is readonly or it doesn't contain keys
         guard existingAccount?.isReadOnly == true || !accountContainsKeys else {
             importedIdentity.duplicateAccounts.append(accountData.name)
             return

--- a/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
@@ -23,8 +23,9 @@ class IdentityImporter {
                 //Here we have an identity stored.
                 //We check whether the identity has its keys and if it does, we try to
                 //import its accounts and mark it as duplicate in the report
+               
                 if let key = existingEntity.encryptedPrivateIdObjectData,
-                    let _ = try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get() {
+                   (try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()) != nil {
                     importAccounts(identityData: identityDataToImport, identityEntity: existingEntity, pwHash: pwHash)
                     importReadOnlyAccounts(readOnlyAccounts, identityEntity: existingEntity, pwHash: pwHash)
                     importReport.duplicateIdentities.append(importedIdentity)
@@ -73,12 +74,11 @@ class IdentityImporter {
     }
 
     private func importAccount(_ accountData: ExportAccount, relatedIdentity: IdentityDataType, pwHash: String) {
-        
         let existingAccount = storageManager.getAccount(withAddress: accountData.address)
         let accountContainsKeys: Bool
         if let storredAccount = existingAccount,
             let key = storredAccount.encryptedPrivateKey,
-            let _ = try? storageManager.getPrivateAccountKeys(key: key, pwHash: pwHash).get() {
+           (try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()) == nil {
             accountContainsKeys = true
         } else {
             accountContainsKeys = false

--- a/ConcordiumWallet/Views/MoreSection/Import/ImportService.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/ImportService.swift
@@ -24,7 +24,10 @@ struct ImportService {
         
         // Logger.debug("import data: \(importedData.prettyPrintedJSONString)");
         
-        _ = try decodeImport(importedData: importedData)
+        let importedObjects = try decodeImport(importedData: importedData)
+        if importedObjects.value.identities.count == 0 {
+            throw ImportError.missingIdentitiesError
+        }
     }
 
     func importFile(from url: URL, pwHash: String, exportPassword: String) throws -> AnyPublisher<ImportedItemsReport, Error> {

--- a/ConcordiumWallet/Views/MoreSection/Import/Importer.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/Importer.swift
@@ -87,11 +87,11 @@ class Importer {
                                 pwHash: String) -> AnyPublisher<[MakeGenerateAccountsResponseElement], Error> {
         // filter accounts included in the import (we only include addresses that are not saved or are readonly or don't contain keys)
         let accountsToVerify = accounts.filter { (account) -> Bool in
-            let storredAccount = storageManager.getAccount(withAddress: account.accountAddress)
+            let storedAccount = storageManager.getAccount(withAddress: account.accountAddress)
             
             let accountContainsKeys: Bool
-            if let storredAccount = storredAccount {
-                let result = mobileWallet.verifyPasscode(for: storredAccount, pwHash: pwHash)
+            if let storedAccount = storedAccount {
+                let result = mobileWallet.verifyPasscode(for: storedAccount, pwHash: pwHash)
                 switch result {
                 case .failure:
                     accountContainsKeys = false
@@ -102,7 +102,7 @@ class Importer {
                 accountContainsKeys = false
             }
             
-            if storredAccount?.isReadOnly == true || !accountContainsKeys {
+            if storedAccount?.isReadOnly == true || !accountContainsKeys {
                 return true
             }
             return false

--- a/ConcordiumWallet/Views/MoreSection/Import/Importer.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/Importer.swift
@@ -83,7 +83,8 @@ class Importer {
                 }}.eraseToAnyPublisher()
     }
     
-    private func verifyAccounts(accounts: [MakeGenerateAccountsResponseElement], pwHash: String) -> AnyPublisher<[MakeGenerateAccountsResponseElement], Error> {
+    private func verifyAccounts(accounts: [MakeGenerateAccountsResponseElement],
+                                pwHash: String) -> AnyPublisher<[MakeGenerateAccountsResponseElement], Error> {
         // filter accounts included in the import (we only include addresses that are not saved or are readonly or don't contain keys)
         let accountsToVerify = accounts.filter { (account) -> Bool in
             let storredAccount = storageManager.getAccount(withAddress: account.accountAddress)

--- a/ConcordiumWallet/Views/MoreSection/Import/Importer.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/Importer.swift
@@ -44,7 +44,7 @@ class Importer {
                                 
                 let accounts = try generateAccounts(identity: importIdentityData, pwHash: pwHash)
                 let mappedImportedAccounts = accounts.map { (accounts) -> AnyPublisher<IdentityDataType?, Error> in
-                    self.verifyAccounts(accounts: accounts).map { (accountElements) in
+                    self.verifyAccounts(accounts: accounts, pwHash: pwHash).map { (accountElements) in
                         self.importIdentity(importIdentityData: importIdentityData,
                                             readOnlyAccounts: accountElements,
                                             pwHash: pwHash) }.eraseToAnyPublisher()
@@ -83,11 +83,25 @@ class Importer {
                 }}.eraseToAnyPublisher()
     }
     
-    private func verifyAccounts(accounts: [MakeGenerateAccountsResponseElement]) -> AnyPublisher<[MakeGenerateAccountsResponseElement], Error> {
-        // filter accounts included in the import (we only include addresses that are now saved or are readonly
+    private func verifyAccounts(accounts: [MakeGenerateAccountsResponseElement], pwHash: String) -> AnyPublisher<[MakeGenerateAccountsResponseElement], Error> {
+        // filter accounts included in the import (we only include addresses that are not saved or are readonly or don't contain keys)
         let accountsToVerify = accounts.filter { (account) -> Bool in
             let storredAccount = storageManager.getAccount(withAddress: account.accountAddress)
-            if storredAccount == nil || storredAccount?.isReadOnly == true {
+            
+            let accountContainsKeys: Bool
+            if let storredAccount = storredAccount {
+                let result = mobileWallet.verifyPasscode(for: storredAccount, pwHash: pwHash)
+                switch result {
+                case .failure:
+                    accountContainsKeys = false
+                case .success:
+                    accountContainsKeys = true
+                }
+            } else {
+                accountContainsKeys = false
+            }
+            
+            if storredAccount?.isReadOnly == true || !accountContainsKeys {
                 return true
             }
             return false

--- a/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
@@ -12,12 +12,18 @@ class MoreCoordinator: Coordinator, ShowAlert {
     var navigationController: UINavigationController
     private var dependencyProvider: MoreFlowCoordinatorDependencyProvider
     private var loginDependencyProvider: LoginDependencyProvider
+    private var sanityChecker: SanityChecker
     
     init(navigationController: UINavigationController,
          dependencyProvider: MoreFlowCoordinatorDependencyProvider & LoginDependencyProvider & WalletAndStorageDependencyProvider) {
         self.navigationController = navigationController
         self.dependencyProvider = dependencyProvider
         self.loginDependencyProvider = dependencyProvider
+        self.sanityChecker = SanityChecker(mobileWallet: dependencyProvider.mobileWallet(),
+                                          storageManager: dependencyProvider.storageManager())
+        sanityChecker.errorDisplayer = self
+        sanityChecker.delegate = self
+        sanityChecker.coordinator = self
     }
 
     func start() {
@@ -70,13 +76,9 @@ class MoreCoordinator: Coordinator, ShowAlert {
     }
     
     func showValidateIdsAndAccounts() {
-        let sanityChecker = SanityChecker(requestPasswordDelegate: self,
-                                          keychainWrapper: dependencyProvider.keychainWrapper(),
-                                          mobileWallet: dependencyProvider.mobileWallet(),
-                                          storageManager: dependencyProvider.storageManager(),
-                                          errorDisplayer: self,
-                                          coordinator: self)
-        sanityChecker.requestPwAndCheckSanity()
+        sanityChecker.requestPwAndCheckSanity(requestPasswordDelegate: self,
+                                              keychainWrapper: dependencyProvider.keychainWrapper(),
+                                              mode: .manual)
     }
 
     private func showCreateExportPassword() -> AnyPublisher<String, Error> {
@@ -227,3 +229,5 @@ extension MoreCoordinator: ExportPresenterDelegate {
 }
 
 extension MoreCoordinator: AboutPresenterDelegate {}
+
+extension MoreCoordinator: ShowImport {}

--- a/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
@@ -7,7 +7,7 @@ import Foundation
 import UIKit
 import Combine
 
-class MoreCoordinator: Coordinator {
+class MoreCoordinator: Coordinator, ShowAlert {
     var childCoordinators = [Coordinator]()
     var navigationController: UINavigationController
     private var dependencyProvider: MoreFlowCoordinatorDependencyProvider
@@ -68,6 +68,16 @@ class MoreCoordinator: Coordinator {
         let vc = ExportFactory.create(with: ExportPresenter(dependencyProvider: dependencyProvider, requestPasswordDelegate: self, delegate: self))
         navigationController.pushViewController(vc, animated: true)
     }
+    
+    func showValidateIdsAndAccounts() {
+        let sanityChecker = SanityChecker(requestPasswordDelegate: self,
+                                          keychainWrapper: dependencyProvider.keychainWrapper(),
+                                          mobileWallet: dependencyProvider.mobileWallet(),
+                                          storageManager: dependencyProvider.storageManager(),
+                                          errorDisplayer: self,
+                                          coordinator: self)
+        sanityChecker.requestPwAndCheckSanity()
+    }
 
     private func showCreateExportPassword() -> AnyPublisher<String, Error> {
         let selectExportPasswordCoordinator = CreateExportPasswordCoordinator(navigationController: TransparentNavigationController(),
@@ -116,6 +126,9 @@ extension MoreCoordinator: MoreMenuPresenterDelegate {
     
     func aboutSelected() {
         showAbout()
+    }
+    func validateIdsAndAccountsSelected() {
+        showValidateIdsAndAccounts()
     }
 }
 
@@ -213,6 +226,4 @@ extension MoreCoordinator: ExportPresenterDelegate {
     }
 }
 
-extension MoreCoordinator: AboutPresenterDelegate {
-    
-}
+extension MoreCoordinator: AboutPresenterDelegate {}

--- a/ConcordiumWallet/Views/MoreSection/MoreMenuPresenter.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreMenuPresenter.swift
@@ -21,6 +21,7 @@ protocol MoreMenuPresenterDelegate: AnyObject {
     func exportSelected()
     func updateSelected()
     func aboutSelected()
+    func validateIdsAndAccountsSelected()
 }
 
 // MARK: -
@@ -33,6 +34,7 @@ protocol MoreMenuPresenterProtocol: AnyObject {
     func userSelectedImport()
     func userSelectedExport()
     func userSelectedUpdate()
+    func userSelectedValidate()
     func userSelectedAbout()
 }
 
@@ -66,5 +68,10 @@ extension MoreMenuPresenter: MoreMenuPresenterProtocol {
     }
     func userSelectedAbout() {
         delegate?.aboutSelected()
+    }
+    func userSelectedValidate() {
+        //TODO: show dialog here
+        delegate?.validateIdsAndAccountsSelected()
+        
     }
 }

--- a/ConcordiumWallet/Views/MoreSection/MoreMenuPresenter.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreMenuPresenter.swift
@@ -70,8 +70,6 @@ extension MoreMenuPresenter: MoreMenuPresenterProtocol {
         delegate?.aboutSelected()
     }
     func userSelectedValidate() {
-        //TODO: show dialog here
         delegate?.validateIdsAndAccountsSelected()
-        
     }
 }

--- a/ConcordiumWallet/Views/MoreSection/MoreMenuViewController.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreMenuViewController.swift
@@ -14,6 +14,7 @@ enum MenuCell: Hashable {
     case import_(title: String)
     case export(title: String)
     case update(title: String)
+    case validate(title: String)
     case about(title: String)
     
 }
@@ -78,6 +79,8 @@ extension MoreMenuViewController: UITableViewDelegate {
             presenter.userSelectedUpdate()
         case .about:
             presenter.userSelectedAbout()
+        case .validate:
+            presenter.userSelectedValidate()
         }
     }
 }
@@ -90,6 +93,7 @@ extension MoreMenuViewController {
         snapshot.appendItems([.import_(title: "more.import".localized)])
         snapshot.appendItems([.export(title: "more.export".localized)])
         snapshot.appendItems([.update(title: "more.update".localized)])
+        snapshot.appendItems([.validate(title: "more.validateIdsAndAccounts".localized)])
         snapshot.appendItems([.about(title: "more.about".localized)])
                 
         DispatchQueue.main.async {
@@ -103,6 +107,7 @@ extension MoreMenuViewController {
              .import_(let title),
              .export(let title),
              .update(let title),
+             .validate(let title),
              .about(let title):
             // swiftlint:disable:next force_cast
             let cell = tableView.dequeueReusableCell(withIdentifier: "MenuItemCellView", for: indexPath) as! MenuItemCellView

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -42,7 +42,7 @@ class SanityChecker {
                 self?.errorDisplayer.showErrorAlert(ErrorMapper.toViewError(error: error))
             }, receiveValue: { [weak self] pwHash in
                 guard let self = self else { return }
-                self.checkSanity(pwHash: pwHash, completion: nil)
+                self.checkSanity(pwHash: pwHash, completion: {})
             }).store(in: &cancellables)
     }
     
@@ -97,7 +97,7 @@ class SanityChecker {
         }
     }
     
-    private func remindMeLater(report: [(IdentityDataType, [AccountDataType])]){
+    private func remindMeLater(report: [(IdentityDataType, [AccountDataType])]) {
         AppSettings.ignoreMissingKeysForIdsOrAccountsAtLogin = false
         markIdsAndAccountsAsReadOnly(report: report)
     }
@@ -110,7 +110,7 @@ class SanityChecker {
     private func markIdsAndAccountsAsReadOnly(report: [(IdentityDataType, [AccountDataType])]) {
         for (_, accounts) in report {
             for account in accounts {
-                let _ = account.withMarkAsReadOnly()
+                _ = account.withMarkAsReadOnly(true)
             }
         }
     }

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -10,53 +10,73 @@ import Foundation
 import Combine
 import UIKit
 
+enum SanityCheckerMode {
+    case automatic
+    case manual
+}
+
+protocol ShowImport: AnyObject {
+    func showImport()
+}
+
 class SanityChecker {
-    var keychainWrapper: KeychainWrapperProtocol
-    var errorDisplayer: ShowAlert
+    var errorDisplayer: ShowAlert?
     var mobileWallet: MobileWalletProtocol
     var storageManager: StorageManagerProtocol
-   
-    weak var requestPasswordDelegate: RequestPasswordDelegate?
     weak var coordinator: Coordinator?
+    weak var delegate: ShowImport?
     
     private var cancellables: [AnyCancellable] = []
     
-    init(requestPasswordDelegate: RequestPasswordDelegate,
-         keychainWrapper: KeychainWrapperProtocol,
-         mobileWallet: MobileWalletProtocol,
-         storageManager: StorageManagerProtocol,
-         errorDisplayer: ShowAlert,
-         coordinator: Coordinator) {
-        self.requestPasswordDelegate = requestPasswordDelegate
-        self.keychainWrapper = keychainWrapper
-        self.errorDisplayer = errorDisplayer
+    static var lastSanityReport: [(IdentityDataType, [AccountDataType])] = []
+    
+    init(mobileWallet: MobileWalletProtocol,
+         storageManager: StorageManagerProtocol) {
         self.mobileWallet = mobileWallet
-        self.coordinator = coordinator
         self.storageManager = storageManager
     }
     
-    public func requestPwAndCheckSanity() {
+    // swiftlint:disable:next line_length
+    public func requestPwAndCheckSanity(requestPasswordDelegate: RequestPasswordDelegate?, keychainWrapper: KeychainWrapperProtocol, mode: SanityCheckerMode) {
         requestPasswordDelegate?.requestUserPassword(keychain: keychainWrapper)
             .sink(receiveError: { [weak self] error in
                 if case GeneralError.userCancelled = error { return }
-                self?.errorDisplayer.showErrorAlert(ErrorMapper.toViewError(error: error))
+                self?.errorDisplayer?.showErrorAlert(ErrorMapper.toViewError(error: error))
             }, receiveValue: { [weak self] pwHash in
                 guard let self = self else { return }
-                self.checkSanity(pwHash: pwHash, completion: {})
+                self.checkSanity(pwHash: pwHash, mode: mode, completion: {})
             }).store(in: &cancellables)
     }
     
-    public func checkSanity(pwHash: String, completion: @escaping () -> Void) {
+    public func getSanityReport(pwHash: String) -> [(IdentityDataType, [AccountDataType])] {
         let report = self.mobileWallet.verifyIdentitiesAndAccounts(pwHash: pwHash)
-        self.showValidateIdentitiesAlert(report: report, completion: completion)
+        SanityChecker.lastSanityReport = report
+        return report
     }
     
-    private func showValidateIdentitiesAlert(report: [(IdentityDataType, [AccountDataType])], completion: @escaping () -> Void) {
+    public func checkSanity(pwHash: String, mode: SanityCheckerMode, completion: @escaping () -> Void) {
+        let report = getSanityReport(pwHash: pwHash)
+        self.showValidateIdentitiesAlert(report: report, mode: mode, completion: completion)
+    }
+    
+    // swiftlint:disable:next line_length
+    public func showValidateIdentitiesAlert(report: [(IdentityDataType, [AccountDataType])], mode: SanityCheckerMode, completion: @escaping () -> Void) {
+        switch mode {
+        case .automatic:
+            if report.count == 0 ||  AppSettings.ignoreMissingKeysForIdsOrAccountsAtLogin == true {
+                return
+            }
+        case .manual:
+            if report.count == 0 {
+                showAllOkAlert()
+                return
+            }
+        }
         var message = "more.validateIdsAndAccount.unusableIdentitiesFound".localized
         for (identity, accounts) in report {
             message += String(format: "more.validateIdsAndAccount.identity".localized, identity.nickname)
             for account in accounts {
-                message += String(format: "more.validateIdsAndAccount.account".localized, (account.name ?? ""))
+                message += String(format: "more.validateIdsAndAccount.account".localized, account.displayName)
             }
         }
         
@@ -67,8 +87,7 @@ class SanityChecker {
         )
         
         let removeAction = UIAlertAction(title: "more.validateIdsAndAccount.removeFromApp".localized, style: .destructive) { [weak self] (_) in
-            self?.removeIdentitiesAndAccountsWithoutKeys(report: report)
-            completion()
+            self?.showSecondConfirmation(report: report, completion: completion)
         }
        
         let remindMeLater = UIAlertAction(title: "more.validateIdsAndAccount.remindLater".localized, style: .default) {  [weak self] (_) in
@@ -76,25 +95,53 @@ class SanityChecker {
             completion()
         }
         
-        let keepAsReadonly = UIAlertAction(title: "more.validateIdsAndAccount.keep".localized, style: .cancel) {  [weak self] (_) in
+        let keepAsReadonly = UIAlertAction(title: "more.validateIdsAndAccount.keep".localized, style: .default) {  [weak self] (_) in
             self?.keepAsReadOnly(report: report)
             completion()
         }
+        let redirectToImport = UIAlertAction(title: "more.validateIdsAndAccount.import".localized, style: .cancel) {  [weak self] (_) in
+            self?.redirectToImport()
+            completion()
+        }
         
-        alert.addAction(removeAction)
+        switch mode {
+        case .automatic:
+            break
+        case .manual:
+            alert.addAction(removeAction)
+        }
+        
         alert.addAction(remindMeLater)
         alert.addAction(keepAsReadonly)
+        alert.addAction(redirectToImport)
         
         coordinator?.navigationController.present(alert, animated: true)
     }
     
-    private func removeIdentitiesAndAccountsWithoutKeys(report: [(IdentityDataType, [AccountDataType])]) {
+    private func redirectToImport() {
+        self.delegate?.showImport()
+    }
+    /*
+     The method returns the identities that failed to be removed. If some of the identities in the report also
+     contain accounts that have keys, that identity will not be removed
+     */
+    private func removeIdentitiesAndAccountsWithoutKeys(report: [(IdentityDataType, [AccountDataType])]) -> [IdentityDataType] {
+        var failToRemoveIdentities = [IdentityDataType]()
         for (identity, accounts) in report {
+            //we remove the readonly accounts from the calculations because they are not
+            // marked as needing deletion (readonly accounts never have keys)
+            let identityAccounts = self.storageManager.getAccounts(for: identity).filter { !$0.isReadOnly }
             for account in accounts {
                 self.storageManager.removeAccount(account: account)
             }
-            self.storageManager.removeIdentity(identity)
+            //if the identity contains also valid accounts, we cannot delete the identity
+            if identityAccounts.count == accounts.count {
+                self.storageManager.removeIdentity(identity)
+            } else {
+                failToRemoveIdentities.append(identity)
+            }
         }
+        return failToRemoveIdentities
     }
     
     private func remindMeLater(report: [(IdentityDataType, [AccountDataType])]) {
@@ -108,10 +155,78 @@ class SanityChecker {
     }
     
     private func markIdsAndAccountsAsReadOnly(report: [(IdentityDataType, [AccountDataType])]) {
+        //only accounts will be marked as readonly because we don't have a readonly state for ids yet
         for (_, accounts) in report {
             for account in accounts {
                 _ = account.withMarkAsReadOnly(true)
             }
         }
+    }
+    
+    private func showSecondConfirmation(report: [(IdentityDataType, [AccountDataType])], completion: @escaping () -> Void) {
+        let alert = UIAlertController(
+            title: "more.validateIdsAndAccount.confirmationtitle".localized,
+            message: "more.validateIdsAndAccount.confirmationtext".localized,
+            preferredStyle: .alert
+        )
+        
+        let removeAction = UIAlertAction(title: "more.validateIdsAndAccount.yesremoveFromApp".localized, style: .destructive) { [weak self] (_) in
+            guard let self = self else { return }
+            let failedToRemoveIdentities = self.removeIdentitiesAndAccountsWithoutKeys(report: report)
+            if failedToRemoveIdentities.count == 0 {
+                completion()
+            } else {
+                self.showAlertForIdentitiesNotDeleted(failedToRemoveIdentities: failedToRemoveIdentities,
+                                                      completion: completion)
+            }
+        }
+        
+        let keepAsReadonly = UIAlertAction(title: "more.validateIdsAndAccount.keep".localized, style: .cancel) {  [weak self] (_) in
+            self?.keepAsReadOnly(report: report)
+            completion()
+        }
+        let redirectToImport = UIAlertAction(title: "more.validateIdsAndAccount.import".localized, style: .default) {  [weak self] (_) in
+            self?.redirectToImport()
+            completion()
+        }
+        alert.addAction(removeAction)
+        alert.addAction(keepAsReadonly)
+        alert.addAction(redirectToImport)
+        coordinator?.navigationController.present(alert, animated: true)
+    }
+    /*
+     This alert is shown in caset the user chooses to delete the identities with missing keys,
+     but some of them still contain accounts with valid keys
+     */
+    private func showAlertForIdentitiesNotDeleted(failedToRemoveIdentities: [IdentityDataType], completion: @escaping () -> Void) {
+        var message = "more.validateIdsAndAccount.idsWithFunctioningAccounts".localized
+        for identity in failedToRemoveIdentities {
+            message += String(format: "more.validateIdsAndAccount.identity".localized, identity.nickname)
+        }
+        
+        let alert = UIAlertController(
+            title: "more.validateIdsAndAccount.simpleWarningTitle".localized,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        let okAction = UIAlertAction(title: "more.validateIdsAndAccount.okay".localized, style: .default) {  (_) in
+            completion()
+        }
+        alert.addAction(okAction)
+        coordinator?.navigationController.present(alert, animated: true)
+    }
+    
+    private func showAllOkAlert() {
+        let alert = UIAlertController(
+            title: "more.validateIdsAndAccount.allOk.title".localized,
+            message: "more.validateIdsAndAccount.allOk.description".localized,
+            preferredStyle: .alert
+        )
+        
+        let okAction = UIAlertAction(title: "more.validateIdsAndAccount.okay".localized, style: .default) {  (_) in
+        }
+        alert.addAction(okAction)
+        coordinator?.navigationController.present(alert, animated: true)
     }
 }

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -128,9 +128,7 @@ class SanityChecker {
     private func removeIdentitiesAndAccountsWithoutKeys(report: [(IdentityDataType, [AccountDataType])]) -> [IdentityDataType] {
         var failToRemoveIdentities = [IdentityDataType]()
         for (identity, accounts) in report {
-            //we remove the readonly accounts from the calculations because they are not
-            // marked as needing deletion (readonly accounts never have keys)
-            let identityAccounts = self.storageManager.getAccounts(for: identity).filter { !$0.isReadOnly }
+            let identityAccounts = self.storageManager.getAccounts(for: identity)
             for account in accounts {
                 self.storageManager.removeAccount(account: account)
             }

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -1,0 +1,104 @@
+//
+//  SanityChecker.swift
+//  ConcordiumWallet
+//
+//  Created by Ruxandra Nistor on 11/01/2022.
+//  Copyright © 2022 concordium. All rights reserved.
+//
+
+import Foundation
+import Combine
+import UIKit
+
+class SanityChecker {
+    var keychainWrapper: KeychainWrapperProtocol
+    var errorDisplayer: ShowAlert
+    var mobileWallet: MobileWalletProtocol
+    var storageManager: StorageManagerProtocol
+   
+    weak var requestPasswordDelegate: RequestPasswordDelegate?
+    weak var coordinator: Coordinator?
+    
+    private var cancellables: [AnyCancellable] = []
+    
+    init(requestPasswordDelegate: RequestPasswordDelegate,
+         keychainWrapper: KeychainWrapperProtocol,
+         mobileWallet: MobileWalletProtocol,
+         storageManager: StorageManagerProtocol,
+         errorDisplayer: ShowAlert,
+         coordinator: Coordinator) {
+        self.requestPasswordDelegate = requestPasswordDelegate
+        self.keychainWrapper = keychainWrapper
+        self.errorDisplayer = errorDisplayer
+        self.mobileWallet = mobileWallet
+        self.coordinator = coordinator
+        self.storageManager = storageManager
+    }
+    
+    public func requestPwAndCheckSanity() {
+        requestPasswordDelegate?.requestUserPassword(keychain: keychainWrapper)
+            .sink(receiveError: { [weak self] error in
+                if case GeneralError.userCancelled = error { return }
+                self?.errorDisplayer.showErrorAlert(ErrorMapper.toViewError(error: error))
+            }, receiveValue: { [weak self] pwHash in
+                guard let self = self else { return }
+                self.checkSanity(pwHash: pwHash)
+            }).store(in: &cancellables)
+    }
+    
+    public func checkSanity(pwHash: String) {
+        let report = self.mobileWallet.verifyIdentitiesAndAccounts(pwHash: pwHash)
+        self.showValidateIdentitiesAlert(report: report)
+    }
+    
+    private func showValidateIdentitiesAlert(report: [(IdentityDataType, [AccountDataType])]) {
+        var message = "more.validateIdsAndAccount.unusableIdentitiesFound".localized
+        for (identity, accounts) in report {
+            message += String(format: "more.validateIdsAndAccount.identity".localized, identity.nickname)
+            for account in accounts {
+                message += String(format: "more.validateIdsAndAccount.account".localized, (account.name ?? ""))
+            }
+        }
+        
+        let alert = UIAlertController(
+            title: "more.validateIdsAndAccount.warningTitle".localized,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        let removeAction = UIAlertAction(title: "more.validateIdsAndAccount.removeFromApp".localized, style: .destructive) { (_) in
+//            completion()
+        }
+       
+        let remindMeLater = UIAlertAction(title: "more.validateIdsAndAccount.remindLater".localized, style: .default) { (_) in
+//            completion()
+        }
+        
+        let keepAsReadonly = UIAlertAction(title: "more.validateIdsAndAccount.keep".localized, style: .cancel) { (_) in
+//            completion()
+        }
+        
+        alert.addAction(removeAction)
+        alert.addAction(remindMeLater)
+        alert.addAction(keepAsReadonly)
+        
+        coordinator?.navigationController.present(alert, animated: true)
+    }
+    
+    private func removeIdentitiesAndAccountsWithoutKeys(report: [(IdentityDataType, [AccountDataType])]) {
+        for (identity, accounts) in report {
+            for account in accounts {
+                self.storageManager.removeAccount(account: account)
+            }
+            self.storageManager.removeIdentity(identity)
+        }
+    }
+    
+    private func remindMeLater() {
+        //TODO: mark accounts as read-only and remind user later
+    }
+    
+    private func keepAsReadOnly() {
+        //TODO: mark accounts as read-only and set a flag not to check this at login
+    }
+}

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -48,14 +48,14 @@ class SanityChecker {
             }).store(in: &cancellables)
     }
     
-    public func getSanityReport(pwHash: String) -> [(IdentityDataType, [AccountDataType])] {
+    public func generateSanityReport(pwHash: String) -> [(IdentityDataType, [AccountDataType])] {
         let report = self.mobileWallet.verifyIdentitiesAndAccounts(pwHash: pwHash)
         SanityChecker.lastSanityReport = report
         return report
     }
     
     public func checkSanity(pwHash: String, mode: SanityCheckerMode, completion: @escaping () -> Void) {
-        let report = getSanityReport(pwHash: pwHash)
+        let report = generateSanityReport(pwHash: pwHash)
         self.showValidateIdentitiesAlert(report: report, mode: mode, completion: completion)
     }
     
@@ -193,7 +193,7 @@ class SanityChecker {
         coordinator?.navigationController.present(alert, animated: true)
     }
     /*
-     This alert is shown in caset the user chooses to delete the identities with missing keys,
+     This alert is shown in case the user chooses to delete the identities with missing keys,
      but some of them still contain accounts with valid keys
      */
     private func showAlertForIdentitiesNotDeleted(failedToRemoveIdentities: [IdentityDataType], completion: @escaping () -> Void) {

--- a/ConcordiumWallet/Views/RootView/MainTabBarController.swift
+++ b/ConcordiumWallet/Views/RootView/MainTabBarController.swift
@@ -57,3 +57,10 @@ extension MainTabBarController: AccountsCoordinatorDelegate {
         identitiesCoordinator.showCreateNewIdentity()
     }
 }
+
+extension MainTabBarController: ShowImport {
+    func showImport() {
+        selectedViewController = moreCoordinator.navigationController
+        moreCoordinator.showImport()
+    }
+}

--- a/ConcordiumWallet/Views/Widgets/CopyReferenceInfoWidgetViewController.swift
+++ b/ConcordiumWallet/Views/Widgets/CopyReferenceInfoWidgetViewController.swift
@@ -39,6 +39,9 @@ class CopyReferenceInfoWidgetViewController: BaseViewController, CopyReferenceIn
         presenter.view = self
         presenter.viewDidLoad()
         
-        label.text = String(format: "copyreference.info.text".localized, presenter.identityProviderName, presenter.identityProviderSupportEmail, AppConstants.Support.concordiumSupportMail)
+        label.text = String(format: "copyreference.info.text".localized,
+                            presenter.identityProviderName,
+                            presenter.identityProviderSupportEmail,
+                            AppConstants.Support.concordiumSupportMail)
     }
 }

--- a/ioscommon/Base/Coordinator.swift
+++ b/ioscommon/Base/Coordinator.swift
@@ -6,7 +6,7 @@
 import Foundation
 import UIKit
 
-protocol Coordinator {
+protocol Coordinator: AnyObject {
     var childCoordinators: [Coordinator] { get set }
     var navigationController: UINavigationController { get set }
 

--- a/ioscommon/Commons/ShowIdentityFailureProtocol.swift
+++ b/ioscommon/Commons/ShowIdentityFailureProtocol.swift
@@ -37,39 +37,29 @@ extension ShowIdentityFailure where Self: IdentityFailableViewController {
             message: nil,
             preferredStyle: .alert
         )
-        
         let tryAgainAction = UIAlertAction(title: "identityfailed.tryagain".localized, style: .default) { _ in
             completion(.tryAgain)
         }
-        
         alert.addAction(tryAgainAction)
-        
-        let supportMailBody = String(
-            format: "supportmail.body".localized,
-            reference,
-            AppSettings.appVersion,
-            AppSettings.buildNumber,
-            AppSettings.iOSVersion
-        )
+        let supportMailBody = String( format: "supportmail.body".localized,
+                                      reference,
+                                      AppSettings.appVersion,
+                                      AppSettings.buildNumber,
+                                      AppSettings.iOSVersion)
         
         if MailHelper.canSendMail {
             let supportAction = UIAlertAction(title: "identityfailed.contactsupport".localized, style: .default) { [weak self] _ in
                 guard let self = self else { return }
-
-                self.launchSupport(
-                    presenter: self,
-                    delegate: self,
-                    recipient: identityProviderSupportEmail,
-                    ccRecipient: concordiumSupportEmail,
-                    subject: String(format: "supportmail.subject".localized, reference),
-                    body: supportMailBody
-                )
+                self.launchSupport(presenter: self,
+                                   delegate: self,
+                                   recipient: identityProviderSupportEmail,
+                                   ccRecipient: concordiumSupportEmail,
+                                   subject: String(format: "supportmail.subject".localized, reference),
+                                   body: supportMailBody)
                 completion(.support)
             }
-            
             alert.message = String(format: "identityfailed.message".localized, identityProviderName)
             alert.addAction(supportAction)
-            
         } else {
             let copyAction = UIAlertAction(title: "identityfailed.copyreference".localized, style: .default) { [weak self] _ in
                 CopyPasterHelper.copy(string: supportMailBody)
@@ -83,7 +73,6 @@ extension ShowIdentityFailure where Self: IdentityFailableViewController {
                                    concordiumSupportEmail)
             alert.addAction(copyAction)
         }
-        
         let cancelAction = UIAlertAction(title: "errorAlert.cancelButton".localized, style: .cancel) { _ in
             completion(.cancel)
         }


### PR DESCRIPTION
## Purpose
Mediates the issues that appear after a user backs up his phone and restores it.
Handles invalid export files
Updates intro info text
Marks the app data as not restorable through iPhone backups so we won't end up having accounts stored on the phone with no keys

Fixes #141 
Fixes #140 

## Changes
Mark app data as not restorable by iPhone backup
There is a sanity check that is performed automatically after login and which can also be triggered manually after clicking the ValidateIds and accounts in the menu.
The missing keys for identities are now handled gracefully (the user is given the option to delete identities and accounts with missing keys)
The accounts with missing keys are marked as readonly if the user chooses to keep them
If the user keeps an identity with missing keys and tries to make an account with it, an informative error is presented
If the identity with missing keys contains a valid account and one without keys, neither the identity nor the valid account will be removed to allow the user to transfer the CCDs from the account
At import, all identities and accounts that have missing keys will be overwritten
A relevant error is shown if the user wants to import an export files with no identities
The text in the intro flow is updated (#140)

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
