### PR TITLE
Fix backup warning

### DIFF
--- a/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
@@ -215,6 +215,11 @@ extension MoreCoordinator: ExportPresenterDelegate {
         let vc = UIActivityViewController(activityItems: [url], applicationActivities: [])
         vc.completionWithItemsHandler = { exportActivityType, completed, _, _ in
             // exportActivityType == nil means that the user pressed the close button on the share sheet
+
+            if completed {
+                AppSettings.needsBackupWarning = false
+            }
+
             if completed || exportActivityType == nil {
                 completion()
                 self.exportFinished()


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-reference-wallet-ios/issues/139

## Changes

* Setting `AppSettings.needsBackupWarning` setting to `false` when backup is performed via `More->Export`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

