### PR TITLE
Change text in backup reminders

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -5006,7 +5006,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5039,7 +5039,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5072,7 +5072,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5105,7 +5105,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5257,7 +5257,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";
@@ -5292,7 +5292,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -104,7 +104,7 @@ add_identity_data = "Reveal Identity Data";
 "accounts.amountwillbeshielded" = "Amount will be shielded";
 "accounts.amountwillbeunshielded" = "Amount will be unshielded";
 
-"accounts.backupwarning.text" = "Some accounts are not backed up. Press here to back them up.";
+"accounts.backupwarning.text" = "As your accounts are not backed up, you risk losing your tokens.";
 
 "gettingstarted.title" = "Getting started";
 "gettingstarted.subtitle" = "Are you new here?";
@@ -433,9 +433,10 @@ process on-chain.";
 "accountfinalized.alert.action.backup" = "Make backup";
 
 "accountfinalized.extrabackup.alert.title" = "⚠️ WARNING ⚠️";
-"accountfinalized.extrabackup.alert.message" = "Are you sure that you do not want to create a backup?\n\nIf you loose your phone and do not have a backup you will no longer have access to your account(s).";
+"accountfinalized.extrabackup.alert.message" = "Are you sure that you do not want to create a backup? You risk losing your CCDs.\n\nIf you lose your phone and do not have a backup you will no longer have access to your account(s) and will lose your CCDs.";
 "accountfinalized.extrabackup.alert.action.dismiss" = "Dismiss";
 
 "backupafterupdate.alert.title" = "Welcome back!";
-"backupafterupdate.alert.message" = "Did you make a backup of your identities and accounts recently?\n\nIf you didn't, now is a good time to do so! Concordium strongly recommends having a backup of all your identities and accounts.";
+"backupafterupdate.alert.message" = "Did you make a backup of your identities and accounts recently?\n\nA backup file is the only way to restore private keys if you lose your phone or re-install the wallet. Without the private keys, you cannot access your accounts. Concordium cannot recover your private keys or export password and you will lose your CCDs. You should export a new backup file EVERY time a new account is created. Protect your export password.\n\nRemember to store the file named
+concordium-backup.concordiumwallet securely.";
 "backupafterupdate.alert.action.notnow" = "Not now";

--- a/ConcordiumWallet/Views/MoreSection/Export/ExportService.swift
+++ b/ConcordiumWallet/Views/MoreSection/Export/ExportService.swift
@@ -24,7 +24,7 @@ struct ExportService {
         let documentDirectory = FileManager.default.urls(for: .documentationDirectory, in: .userDomainMask).first!
         // it appears that the documentation directory does not necessarily exist in advance - create it if it doesn't
         try? FileManager.default.createDirectory(at: documentDirectory, withIntermediateDirectories: true)
-        return documentDirectory.appendingPathComponent("export.concordiumwallet")
+        return documentDirectory.appendingPathComponent("concordium-backup.concordiumwallet")
     }
 
     func deleteExportFile() throws {


### PR DESCRIPTION
## Purpose

Closes #150

## Changes

* Updated localizations
* Renamed exported backup file to `concordium-backup.concordiumwallet`

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

