### PR TITLE
Fix for Notabene's selfie mode

### DIFF
--- a/ConcordiumWallet/Storyboards/Identity.storyboard
+++ b/ConcordiumWallet/Storyboards/Identity.storyboard
@@ -166,12 +166,12 @@ Note: More Identity Issuers are coming soon!</string>
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oeu-Xf-dm2">
+                            <wkWebView clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oeu-Xf-dm2">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <wkWebViewConfiguration key="configuration">
-                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
-                                    <wkPreferences key="preferences"/>
+                                <wkWebViewConfiguration key="configuration" allowsInlineMediaPlayback="YES">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" audio="YES" video="YES"/>
+                                    <wkPreferences key="preferences" javaScriptCanOpenWindowsAutomatically="YES"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="meQ-vP-ar4">


### PR DESCRIPTION
## Purpose

Fixing an issue where the "live broadcasting" camera mode was dismissing the "Onfido/Notabene" selfie frame. 

## Changes

Toggled the settings below of `IdentityProviderWebViewViewController` 's `WebView` . 

![Screenshot 2022-01-24 at 13 18 53](https://user-images.githubusercontent.com/8437817/150783547-20c788c8-5d8e-4fba-86ac-180ef587b07b.png)


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
