### PR TITLE
Testflight background crash

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -5072,7 +5072,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5105,7 +5105,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";

--- a/ConcordiumWallet.xcodeproj/xcshareddata/xcschemes/ProdTestNet.xcscheme
+++ b/ConcordiumWallet.xcodeproj/xcshareddata/xcschemes/ProdTestNet.xcscheme
@@ -34,7 +34,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "1"
+      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/ConcordiumWallet.xcodeproj/xcshareddata/xcschemes/ProdTestNet.xcscheme
+++ b/ConcordiumWallet.xcodeproj/xcshareddata/xcschemes/ProdTestNet.xcscheme
@@ -34,7 +34,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "0"
+      launchStyle = "1"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/ConcordiumWallet/AppDelegate.swift
+++ b/ConcordiumWallet/AppDelegate.swift
@@ -15,9 +15,9 @@ extension Notification.Name {
 // @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
-    var appCoordinator: AppCoordinator {
+    lazy var appCoordinator: AppCoordinator = {
         AppCoordinator()
-    }
+    }()
 
     private lazy var backgroundWindow: UIWindow = {
         let window = UIWindow(frame: UIScreen.main.bounds)

--- a/ConcordiumWallet/AppDelegate.swift
+++ b/ConcordiumWallet/AppDelegate.swift
@@ -15,7 +15,9 @@ extension Notification.Name {
 // @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
-    var appCoordinator = AppCoordinator()
+    var appCoordinator: AppCoordinator {
+        AppCoordinator()
+    }
 
     private lazy var backgroundWindow: UIWindow = {
         let window = UIWindow(frame: UIScreen.main.bounds)
@@ -33,8 +35,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Warn if device is jail broken.
         if UIDevice.current.isJailBroken {
             let ac = UIAlertController(title: "Warning", message: "error", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "errorAlert.okButton".localized, style: .default) { (_) in
-                self.appCoordinator.start()
+            let okAction = UIAlertAction(title: "errorAlert.okButton".localized, style: .default) { [weak self] (_) in
+                self?.appCoordinator.start()
             }
             ac.addAction(okAction)
             appCoordinator.navigationController.present(ac, animated: true)


### PR DESCRIPTION
## Purpose

During pre-warm (introduced in iOS 15), the app would crash in the background leading to showing many crash report errors when installing from TestFlight.

## Changes

The AppCoordinator is now lazily initialised, so it will only reach the Realm initialisation code when the user opens the app and application:didFinishLaunchingWithOptions:  is called

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
