### PR TITLE
Don't show backup warning on fresh install

### DIFF
--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -30,13 +30,12 @@ class AppCoordinator: NSObject, Coordinator, ShowAlert, RequestPasswordDelegate 
             clearAppDataFromPreviousInstall()
         }
 
-        UserDefaults.standard.set(true, forKey: "hasRunBefore")
+        AppSettings.hasRunBefore = true
         showLogin()
     }
     
     private func isNewAppInstall() -> Bool {
-        let hasRunBefore = UserDefaults.standard.bool(forKey: "hasRunBefore")
-        return !hasRunBefore
+        return !AppSettings.hasRunBefore
     }
 
     private func clearAppDataFromPreviousInstall() {

--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -21,6 +21,7 @@ enum UserDefaultKeys: String {
     case ignoreMissingKeysForIdsOrAccountsAtLogin
     case needsBackupWarning
     case lastKnownAppVersionSinceBackupWarning
+    case hasRunBefore
 }
 
 struct AppSettings {
@@ -104,6 +105,15 @@ struct AppSettings {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.lastKnownAppVersionSinceBackupWarning.rawValue)
+        }
+    }
+
+    static var hasRunBefore: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: UserDefaultKeys.hasRunBefore.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.hasRunBefore.rawValue)
         }
     }
     

--- a/ConcordiumWallet/Settings/AppSettings.swift
+++ b/ConcordiumWallet/Settings/AppSettings.swift
@@ -20,7 +20,7 @@ enum UserDefaultKeys: String {
     case acceptedTermsHash
     case ignoreMissingKeysForIdsOrAccountsAtLogin
     case needsBackupWarning
-    case lastKnownAppVersionSinceBackupWarning
+    case lastKnownAppVersion
     case hasRunBefore
 }
 
@@ -99,12 +99,12 @@ struct AppSettings {
         }
     }
 
-    static var lastKnownAppVersionSinceBackupWarning: String? {
+    static var lastKnownAppVersion: String? {
         get {
-            UserDefaults.standard.string(forKey: UserDefaultKeys.lastKnownAppVersionSinceBackupWarning.rawValue)
+            UserDefaults.standard.string(forKey: UserDefaultKeys.lastKnownAppVersion.rawValue)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.lastKnownAppVersionSinceBackupWarning.rawValue)
+            UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.lastKnownAppVersion.rawValue)
         }
     }
 

--- a/ConcordiumWallet/Views/AccountsView/InitialAccount/InitialAccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/InitialAccount/InitialAccountsCoordinator.swift
@@ -33,6 +33,7 @@ class InitialAccountsCoordinator: Coordinator, ShowAlert {
 
     func start() {
         showGettingStarted()
+        AppSettings.lastKnownAppVersion = AppSettings.appVersion // Surpress the welcome back backup warning
     }
 
     func showGettingStarted() {

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -65,7 +65,7 @@ class SanityChecker {
         switch mode {
         case .automatic:
             if report.count == 0 || AppSettings.ignoreMissingKeysForIdsOrAccountsAtLogin == true {
-                if AppSettings.lastKnownAppVersionSinceBackupWarning == nil {
+                if AppSettings.lastKnownAppVersionSinceBackupWarning == nil, AppSettings.hasRunBefore {
                     showBackupWarningAfterUpdate()
                     AppSettings.lastKnownAppVersionSinceBackupWarning = AppSettings.appVersion
                 } else if let lastKnownAppVersionSinceBackupWarning = AppSettings.lastKnownAppVersionSinceBackupWarning, lastKnownAppVersionSinceBackupWarning < AppSettings.appVersion {

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -65,12 +65,12 @@ class SanityChecker {
         switch mode {
         case .automatic:
             if report.count == 0 || AppSettings.ignoreMissingKeysForIdsOrAccountsAtLogin == true {
-                if AppSettings.lastKnownAppVersionSinceBackupWarning == nil, AppSettings.hasRunBefore {
+                if AppSettings.lastKnownAppVersion == nil {
                     showBackupWarningAfterUpdate()
-                    AppSettings.lastKnownAppVersionSinceBackupWarning = AppSettings.appVersion
-                } else if let lastKnownAppVersionSinceBackupWarning = AppSettings.lastKnownAppVersionSinceBackupWarning, lastKnownAppVersionSinceBackupWarning < AppSettings.appVersion {
+                    AppSettings.lastKnownAppVersion = AppSettings.appVersion
+                } else if let lastKnownAppVersion = AppSettings.lastKnownAppVersion, lastKnownAppVersion < AppSettings.appVersion {
                     showBackupWarningAfterUpdate()
-                    AppSettings.lastKnownAppVersionSinceBackupWarning = AppSettings.appVersion
+                    AppSettings.lastKnownAppVersion = AppSettings.appVersion
                 }
                 
                 return


### PR DESCRIPTION
## Purpose

Currently the backup warning alert is shown after a fresh app install, which should not be the case

Relates to #147 

## Changes

* Made `hasRunBefore` a setting in `AppSettings` 
* Checking for `hasRunBefore` before showing the backup warning alert

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

