### PR TITLE
Reload Accounts after dismiss of backup warning

### DIFF
--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -66,10 +66,10 @@ class SanityChecker {
         case .automatic:
             if report.count == 0 || AppSettings.ignoreMissingKeysForIdsOrAccountsAtLogin == true {
                 if AppSettings.lastKnownAppVersion == nil {
-                    showBackupWarningAfterUpdate()
+                    showBackupWarningAfterUpdate(completion: completion)
                     AppSettings.lastKnownAppVersion = AppSettings.appVersion
                 } else if let lastKnownAppVersion = AppSettings.lastKnownAppVersion, lastKnownAppVersion.versionCompare(AppSettings.appVersion) != .orderedSame  {
-                    showBackupWarningAfterUpdate()
+                    showBackupWarningAfterUpdate(completion: completion)
                     AppSettings.lastKnownAppVersion = AppSettings.appVersion
                 }
                 
@@ -237,7 +237,7 @@ class SanityChecker {
         coordinator?.navigationController.present(alert, animated: true)
     }
 
-    private func showBackupWarningAfterUpdate() {
+    private func showBackupWarningAfterUpdate(completion: @escaping () -> Void) {
         let alert = UIAlertController(
             title: "backupafterupdate.alert.title".localized,
             message: "backupafterupdate.alert.message".localized,
@@ -257,7 +257,10 @@ class SanityChecker {
                 let dismissAction = UIAlertAction(
                     title: "accountfinalized.extrabackup.alert.action.dismiss".localized,
                     style: .destructive,
-                    handler: { _ in }
+                    handler: { _ in
+                        AppSettings.needsBackupWarning = true
+                        completion()
+                    }
                 )
 
                 let makeBackupAction = UIAlertAction(


### PR DESCRIPTION
## Purpose

Fixes https://github.com/Concordium/concordium-reference-wallet-ios/issues/150#issuecomment-1023023248

## Changes

* Setting `AppSettings.needsBackupWarning=true` 
* Passing completion handler in order to reload accounts after backup warning dismissal. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

