### PR TITLE
Display dialog and box if the account is finished while user is waiting in the identities screen

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -5006,7 +5006,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5039,7 +5039,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";

--- a/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
+++ b/ConcordiumWallet/Views/Identities/CreateIdentity/CreateIdentityCoordinator.swift
@@ -112,6 +112,7 @@ class CreateIdentityCoordinator: Coordinator, ShowAlert {
         newAccount.encryptedPrivateKey = createdIdentity.encryptedPrivateKey
         newAccount.identity = newIdentity
         _ = try storageManager.storeAccount(newAccount)
+        storageManager.storePendingAccount(with: newAccount.address)
         let shieldedAmount = ShieldedAmountTypeFactory.create().withInitialValue(for: newAccount)
         _ = try storageManager.storeShieldedAmount(amount: shieldedAmount)
         


### PR DESCRIPTION
## Purpose

Fixes #162 

## Changes

Pending account is now stored when Account is created as part of an identity

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
