### PR TITLE
Fix identity background crash

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -207,6 +207,8 @@ class AccountsPresenter: AccountsPresenterProtocol {
     }
     
     func refresh() {
+        cancellables.removeAll()
+        self.view?.hideLoading()
         refresh(showLoadingIndicator: false)
         checkPendingAccountsStatusesIfNeeded()
     }
@@ -359,16 +361,6 @@ class AccountsPresenter: AccountsPresenterProtocol {
         }
     }
     
-    private func cleanIdentitiesAndAccounts() {
-        let accounts = dependencyProvider.storageManager().getAccounts().filter { $0.transactionStatus == SubmissionStatusEnum.absent }
-        for account in accounts {
-            dependencyProvider.storageManager().removeAccount(account: account)
-        }
-        let identities = dependencyProvider.storageManager().getIdentities().filter { $0.state == .failed }
-        for identity in identities {
-            dependencyProvider.storageManager().removeIdentity(identity)
-        }
-    }
     
     func createAccountViewModelWithUpdatedStatus(accounts: [AccountDataType]) -> [AccountViewModel] {
         accounts.map { account in

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -207,8 +207,6 @@ class AccountsPresenter: AccountsPresenterProtocol {
     }
     
     func refresh() {
-        cancellables.removeAll()
-        self.view?.hideLoading()
         refresh(showLoadingIndicator: false)
         checkPendingAccountsStatusesIfNeeded()
     }

--- a/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsViewController.swift
@@ -77,6 +77,12 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
         super.viewWillAppear(animated)
         presenter?.viewWillAppear()
         startRefreshTimer()
+
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        presenter?.viewDidAppear()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(appDidBecomeActive),
                                                name: UIApplication.didBecomeActiveNotification,
@@ -86,12 +92,7 @@ class AccountsViewController: BaseViewController, Storyboarded, AccountsViewProt
                                                name: UIApplication.willResignActiveNotification,
                                                object: nil)
     }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        presenter?.viewDidAppear()
-    }
-
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         stopRefreshTimer()

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
@@ -85,17 +85,7 @@ class IdentitiesPresenter: IdentityGeneralPresenter {
             }
         }
     }
-    
-    private func cleanIdentitiesAndAccounts() {
-        let accounts = dependencyProvider.storageManager().getAccounts().filter { $0.transactionStatus == SubmissionStatusEnum.absent }
-        for account in accounts {
-            dependencyProvider.storageManager().removeAccount(account: account)
-        }
-        let identities = dependencyProvider.storageManager().getIdentities().filter { $0.state == .failed }
-        for identity in identities {
-            dependencyProvider.storageManager().removeIdentity(identity)
-        }
-    }
+
 
     override func createIdentitySelected() {
         self.delegate?.createIdentitySelected()


### PR DESCRIPTION
## Purpose

Fix race condition on the AccountsPresenter that was usually causing it to crash when the identity issuance finished with an error while the app was closed
Fixes #130

## Changes

Subscribing to app appDidBecomeActive and willResignActiveNotification in viewDidAppear which will make it not being triggered when opening the app for the first time

Removed some unused code

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
