### PR TITLE
Fixes/UI fixes

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -5376,7 +5376,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5409,7 +5409,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "ConcordiumWallet/Resources/Entitlements/Concordium ID.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist";
@@ -5442,7 +5442,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5475,7 +5475,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/ProdMainNet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist";
@@ -5627,7 +5627,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";
@@ -5662,7 +5662,7 @@
 				CODE_SIGN_ENTITLEMENTS = ConcordiumWallet/Resources/Entitlements/StagingNet.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_TEAM = K762RM4LQ3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -122,7 +122,7 @@ add_identity_data = "Reveal Identity Data";
  "accounts.alert.shiededtransactions.message" = "Your account %@ has received a shielded transaction, and the shielded balance of %@ is currently hidden.\n\n
 You can show the shielded balance of the account via the option below, or later via the menu in the upper right corner of the account’s page.";
  "accounts.alert.shiededtransactions.show" = "Show shielded balance on %@";
- "accounts.alert.shiededtransactions.later" = "Later";
+ "accounts.alert.shiededtransactions.later" = "Don't show again";
 
 
 "gettingstarted.title" = "Getting started";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -484,7 +484,7 @@ concordium-backup.concordiumwallet securely.";
 "onboardingcarousel.shieldedbalance.title" = "Shielded Balance";
 "onboardingcarousel.shieldedbalance.page1.title" = "Before you continue";
 "onboardingcarousel.shieldedbalance.page2.title" = "Before you continue";
-"onboardingcarousel.shieldedbalance.page3.title" = "The shielded transfer";
+"onboardingcarousel.shieldedbalance.page3.title" = "The shielding transaction";
 "onboardingcarousel.shieldedbalance.page4.title" = "The shielded transfer";
 "onboardingcarousel.shieldedbalance.page5.title" = "The shielded transfer";
 "onboardingcarousel.shieldedbalance.page6.title" = "The unshielding transaction";

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
@@ -170,7 +170,8 @@ extension AccountDetailsPresenter: AccountDetailsPresenterProtocol {
     }
     
     fileprivate func updateTransfers() {
-        accountsService.updateAccountBalancesAndDecryptIfNeeded(account: account, balanceType: balanceType, requestPasswordDelegate: delegate!)
+        guard let delegate = delegate else { return }
+        accountsService.updateAccountBalancesAndDecryptIfNeeded(account: account, balanceType: balanceType, requestPasswordDelegate: delegate)
             .mapError(ErrorMapper.toViewError)
             .sink(receiveError: { [weak self] error in
                 self?.view?.showErrorAlert(error)

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
@@ -133,11 +133,10 @@ extension AccountDetailsPresenter: AccountDetailsPresenterProtocol {
         account = account.withShowShielded(shouldShow)
         if shouldShow {
             switchToBalanceType(.shielded)
-            userSelectedTransfers()
         } else {
             switchToBalanceType(.balance)
-            userSelectedTransfers()
         }
+        userSelectedTransfers()
     }
     
     func switchToBalanceType(_ balanceType: AccountBalanceTypeEnum) {

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
@@ -133,8 +133,10 @@ extension AccountDetailsPresenter: AccountDetailsPresenterProtocol {
         account = account.withShowShielded(shouldShow)
         if shouldShow {
             switchToBalanceType(.shielded)
+            userSelectedTransfers()
         } else {
             switchToBalanceType(.balance)
+            userSelectedTransfers()
         }
     }
     
@@ -249,6 +251,7 @@ extension AccountDetailsPresenter: AccountDetailsPresenterProtocol {
             .sink(receiveError: {[weak self] error in
                 self?.view?.showErrorAlert(error)
                 }, receiveValue: { [weak self] _ in
+                    self?.switchToBalanceType(.shielded)
                     self?.updateTransfers()
             }).store(in: &cancellables)
     }

--- a/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
@@ -145,7 +145,9 @@ extension AccountsCoordinator: CreateNewAccountDelegate {
 extension AccountsCoordinator: AccountDetailsDelegate {
     func accountDetailsClosed() {
         navigationController.dismiss(animated: true, completion: nil)
-        childCoordinators.removeAll(where: { $0 is AccountDetailsCoordinator })
+        if let lastOccurenceIndex = childCoordinators.lastIndex(where: { $0 is AccountDetailsCoordinator }) {
+            childCoordinators.remove(at: lastOccurenceIndex)
+        }
     }
     
     func retryCreateAccount(failedAccount: AccountDataType) {

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -235,9 +235,9 @@ class AccountsPresenter: AccountsPresenterProtocol {
                 
 //                let countLocked = updatedAccounts.filter { $0.encryptedBalanceStatus != ShieldedAccountEncryptionStatus.decrypted }.count
 //                self.viewModel.totalBalanceLockStatus = countLocked > 0 ? .encrypted : .decrypted
-                //we add to the alert list all the accounts that have something in the shielded balance, but do not show a shielded balance
+                //we add to the alert list all the non read-only accounts that have something in the shielded balance, but do not show a shielded balance 
                 let accountsWithPendingShieldedTransactions = updatedAccounts.filter { account in
-                    account.hasShieldedTransactions && !account.showsShieldedBalance
+                    (account.hasShieldedTransactions && !account.showsShieldedBalance && !account.isReadOnly)
                 }
                 for account in accountsWithPendingShieldedTransactions {
                     //we add the alert in the queue (the queue knows whether it needs to show it and when)

--- a/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
@@ -409,7 +409,7 @@ class SendFundPresenter: SendFundPresenterProtocol {
 
 extension SendFundPresenter: ScanAddressQRPresenterDelegate {
     func scanAddressQr(didScanAddress: String) {
-        self.selectedRecipient = RecipientEntity(name: "", address: didScanAddress)
+        self.setSelectedRecipient(recipient: RecipientEntity(name: "", address: didScanAddress))
         self.delegate?.dismissQR()
     }
 }


### PR DESCRIPTION
## Purpose

Fixes #219
Fixes #224
Fixes #220 and #228  (same underlying issue)


## Changes

Updated heading text
We now remove the childCoordinators for AccountDetails coordinator as we would in a stack, from back to front instead of removing all of them
Fixes issue with shielded balance not showing decrypt and not updating to shielded transactions
Fixed needing to press the send button twice after QR scanning 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
