### PR TITLE
make sure we have the necessary camera permissions before showing QR …

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/Recipient/SelectRecepient/SelectRecipientPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/Recipient/SelectRecepient/SelectRecipientPresenter.swift
@@ -51,7 +51,7 @@ class RecipientListViewModel {
 }
 
 // MARK: View
-protocol SelectRecipientViewProtocol: AnyObject {
+protocol SelectRecipientViewProtocol: ShowAlert {
     func bind(to viewModel: RecipientListViewModel)
 }
 
@@ -162,7 +162,22 @@ extension SelectRecipientPresenter: SelectRecipientPresenterProtocol {
     }
 
     func scanQrTapped() {
-        delegate?.selectRecipientDidSelectQR()
+        PermissionHelper.requestAccess(for: .camera) { [weak self] permissionGranted in
+            guard let self = self else { return }
+            
+            guard permissionGranted else {
+                self.view?.showRecoverableErrorAlert(
+                    .cameraAccessDeniedError,
+                    recoverActionTitle: "errorAlert.continueButton".localized,
+                    hasCancel: true
+                ) {
+                    SettingsHelper.openAppSettings()
+                }
+                return
+            }
+
+            self.delegate?.selectRecipientDidSelectQR()
+        }
     }
     
     func userDelete(recipientVM: RecipientViewModel) {


### PR DESCRIPTION
…scanner

## Purpose

This PR fixes a bug where the user would be presented with a black screen if they try to scan a QR code but had revoked camera permissions for the app.

## Changes

The app now checks for camera permissions before launching the QR scanner. If they are not granted it presents a dialog which directs the user to the settings page.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
