### PR TITLE
Feature/missing error dialog on failed identity

### DIFF
--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -66,7 +66,7 @@ class AppCoordinator: NSObject, Coordinator, ShowAlert, RequestPasswordDelegate 
         self.navigationController.setNavigationBarHidden(true, animated: false)
         self.navigationController.pushViewController(tabBarController, animated: true)
         sanityChecker.showValidateIdentitiesAlert(report: SanityChecker.lastSanityReport, mode: .automatic, completion: {
-            //reload accounts tab
+            // reload accounts tab
             accountsCoordinator.start()
         })
     }

--- a/ConcordiumWallet/Model/Mock/MockedData.swift
+++ b/ConcordiumWallet/Model/Mock/MockedData.swift
@@ -109,10 +109,10 @@ class MockedData: ShowToast {
                          "5HJ53TL996fJK900AGC9876",
                          "6HJ63GH65KKJK900AGC9899"]
         for _ in 0..<10 {
-            let name = names[Int(arc4random()) % 3]
-            let address = addresses[Int(arc4random()) % 3]
-            let mockRecipient = RecipientEntity(name: name, address: address)
-            recipients.append(mockRecipient)
+            if let name = names.randomElement(), let address = addresses.randomElement() {
+                let mockRecipient = RecipientEntity(name: name, address: address)
+                recipients.append(mockRecipient)
+            }
         }
         return recipients
     }

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -435,8 +435,7 @@ process on-chain.";
 "identityfailed.copyreference" = "Copy reference";
 "identityfailed.contactsupport" = "Contact Support";
 
-"identityCreation.hasPending" = "Identity issuance pending";
-"identityCreation.hasPending.message" = "Please wait for the pending issuance to complete before creating another";
+"identityCreation.hasPending" = "You can only have one identity request open at a time. Please wait for your currently pending request to finish before starting a new one.";
 
 "releaseschedule.title" = "Release Schedule";
 "releaseschedule.dateandtime" = "Release date and time";

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -435,6 +435,9 @@ process on-chain.";
 "identityfailed.copyreference" = "Copy reference";
 "identityfailed.contactsupport" = "Contact Support";
 
+"identityCreation.hasPending" = "Identity issuance pending";
+"identityCreation.hasPending.message" = "Please wait for the pending issuance to complete before creating another";
+
 "releaseschedule.title" = "Release Schedule";
 "releaseschedule.dateandtime" = "Release date and time";
 "releaseschedule.amount" = "Amount";

--- a/ConcordiumWallet/Service/MobileWallet.swift
+++ b/ConcordiumWallet/Service/MobileWallet.swift
@@ -366,14 +366,14 @@ class MobileWallet: MobileWalletProtocol {
         
         var report: [(IdentityDataType?, [AccountDataType])] = []
         
-        //the identity is invalid if the privateIdObjectData cannot be retrieved from storage
+        // the identity is invalid if the privateIdObjectData cannot be retrieved from storage
         let allIdentities = storageManager.getIdentities()
         let invalidIdentities = allIdentities.filter { identity in
             if let key = identity.encryptedPrivateIdObjectData,
                 (try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()) != nil {
-                return false //it is not invalid because we have privateIdObjectData
+                return false // it is not invalid because we have privateIdObjectData
             }
-            return true //invalid becaut privateIdObjectData could not be retrieved
+            return true // invalid becaut privateIdObjectData could not be retrieved
         }
         for identity in allIdentities {
             let identityAccounts = storageManager.getAccounts(for: identity)
@@ -385,13 +385,13 @@ class MobileWallet: MobileWalletProtocol {
                     return true
                 }
             }
-            //we add to the report invalid identities (even if their accounts are valid) and valid identities with invalid accounts
+            // we add to the report invalid identities (even if their accounts are valid) and valid identities with invalid accounts
             if(invalidIdentities.contains(where: { $0.identityObject?.preIdentityObject.pubInfoForIP.idCredPub  == identity.identityObject?.preIdentityObject.pubInfoForIP.idCredPub }) || invalidAccountNames.count > 0) {
                 report.append((identity, invalidAccountNames))
             }
         }
         
-        //we add to the report any dangling accounts
+        // we add to the report any dangling accounts
         let allAccounts = storageManager.getAccounts()
         let invalidAccounts = allAccounts.filter {
             return (try? verifyPasscode(for: $0, pwHash: pwHash).get()) == nil

--- a/ConcordiumWallet/Views/AccountsView/AccountCardView.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountCardView.swift
@@ -31,7 +31,7 @@ class AccountCardView: UIView, NibLoadable {
     
     @IBOutlet weak private var widget: WidgetView!
     
-    //Contained in accountView
+    // Contained in accountView
     @IBOutlet weak private var accountName: UILabel!
     @IBOutlet weak var initialAccountLabel: UILabel!
     @IBOutlet weak private var pendingImageView: UIImageView!
@@ -39,12 +39,12 @@ class AccountCardView: UIView, NibLoadable {
     @IBOutlet weak private var stateImageView: UIImageView!
     @IBOutlet weak private var stateLabel: UILabel!
     
-    //Contained in totalView
+    // Contained in totalView
     @IBOutlet weak private var totalLabel: UILabel!
     @IBOutlet weak private var totalAmount: UILabel!
     @IBOutlet weak private var totalAmountLockImageView: UIImageView!
     
-    //Contained in atDisposalView
+    // Contained in atDisposalView
     @IBOutlet weak private var atDisposalLabel: UILabel!
     @IBOutlet weak private var atDisposalAmount: UILabel!
     

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsCoordinator.swift
@@ -303,7 +303,7 @@ extension AccountDetailsCoordinator: BurgerMenuAccountDetailsPresenterDelegate {
             showTransferFilters(account: account)
         case .shieldedBalance(_, let shouldShow, let showShieldedDelegate):
             keyWindow?.rootViewController?.dismiss(animated: false, completion: nil)
-            //we only go to the onboarding flow if we should show the shielded balance
+            // we only go to the onboarding flow if we should show the shielded balance
             if shouldShow {
                 showShieldedBalanceOnboarding(showShieldedDelegate: showShieldedDelegate)
             }

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
@@ -398,8 +398,8 @@ extension AccountDetailsPresenter: BurgerMenuAccountDetailsDismissDelegate {
     func bugerMenuDismissedWithAction(_action action: BurgerMenuAccountDetailsAction) {
         self.viewModel.menuState = .closed
         if case let BurgerMenuAccountDetailsAction.shieldedBalance(_, shouldShow, _ ) = action {
-            //we only take action here for hiding the shielded balance.
-            //The showing will be done after the carousel is being presented
+            // we only take action here for hiding the shielded balance.
+            // The showing will be done after the carousel is being presented
             if !shouldShow {
                 showShieldedBalance(shouldShow: false)
             }

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
@@ -18,7 +18,6 @@ class AccountDetailsFactory {
     }
 }
 
-// swiftlint:disable:next type_body_length
 class AccountDetailsViewController: BaseViewController, AccountDetailsViewProtocol, Storyboarded, ShowAlert {
     
     var presenter: AccountDetailsPresenterProtocol
@@ -165,7 +164,6 @@ class AccountDetailsViewController: BaseViewController, AccountDetailsViewProtoc
     }
     
     // swiftlint:disable function_body_length
-    // swiftlint:disable cyclomatic_complexity
     func bind(to viewModel: AccountDetailsViewModel) {
         self.showTransferData(accountState: viewModel.accountState, isReadOnly: viewModel.isReadOnly, hasTransfers: viewModel.hasTransfers)
         

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/BurgerMenu/AccountDetailsBurgerMenu/BurgerMenuAccountDetailsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/BurgerMenu/AccountDetailsBurgerMenu/BurgerMenuAccountDetailsPresenter.swift
@@ -8,17 +8,14 @@
 
 import Foundation
 
-
 // MARK: Delegate
 protocol BurgerMenuAccountDetailsPresenterDelegate: AnyObject {
     func pressedOption(action: BurgerMenuAccountDetailsAction, account: AccountDataType)
 }
 
-
 protocol BurgerMenuAccountDetailsDismissDelegate: AnyObject {
     func bugerMenuDismissedWithAction(_action: BurgerMenuAccountDetailsAction)
 }
-
 
 enum BurgerMenuAccountDetailsAction: BurgerMenuAction {
     case releaseSchedule
@@ -42,7 +39,7 @@ enum BurgerMenuAccountDetailsAction: BurgerMenuAction {
         case .decrypt:
             return "burgermenu.decrypt".localized
         case .dismiss:
-            return "" //this will not be shown in the ui
+            return "" // this will not be shown in the ui
         }
     }
 }
@@ -96,7 +93,6 @@ class BurgerMenuAccountDetailsPresenter: BurgerMenuPresenterProtocol {
         viewModel.setup(actions: actions)
         view?.bind(to: viewModel)
         
-        
     }
     
     func selectedAction(at index: Int) {
@@ -107,7 +103,7 @@ class BurgerMenuAccountDetailsPresenter: BurgerMenuPresenterProtocol {
     func selectedAction(_ action: BurgerMenuAccountDetailsAction) {
         let account: AccountDataType!
         if case .shieldedBalance = action, self.account.showsShieldedBalance {
-            //if we are hiding it, we hide it here directly
+            // if we are hiding it, we hide it here directly
             account = self.account.withShowShielded(!self.account.showsShieldedBalance)
         } else {
             account = self.account

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/BurgerMenu/BurgerMenuOptionCell.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/BurgerMenu/BurgerMenuOptionCell.swift
@@ -12,7 +12,6 @@ protocol BurgerMenuOptionCellDelegate: AnyObject {
     func selectedCellAt(row: Int)
 }
 
-
 class BurgerMenuOptionCell: UITableViewCell {
 
     private var cellRow: Int = 0
@@ -30,7 +29,6 @@ class BurgerMenuOptionCell: UITableViewCell {
 
         // Configure the view for the selected state
     }
-
     
     func setup(cellRow: Int, title: String, delegate: BurgerMenuOptionCellDelegate) {
         self.cellRow = cellRow

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/BurgerMenu/BurgerMenuViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/BurgerMenu/BurgerMenuViewController.swift
@@ -17,7 +17,7 @@ class BurgerMenuFactory {
     }
 }
 
-class BurgerMenuViewController: BaseViewController, BurgerMenuViewProtocol, Storyboarded, ShowToast  {
+class BurgerMenuViewController: BaseViewController, BurgerMenuViewProtocol, Storyboarded, ShowToast {
     
     @IBOutlet weak var tableView: UITableView!
     

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/TransactionDetail/TransactionDetailViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/TransactionDetail/TransactionDetailViewController.swift
@@ -235,7 +235,7 @@ extension TransactionDetailViewController: UITableViewDelegate {
             case .origin(let vm), .to(let vm), .from(let vm), .blockHash(let vm), .transactionHash(let vm), .details(let vm):
                 CopyPasterHelper.copy(string: vm.value)
                 self.showToast(withMessage: "general.copied".localized + " " + vm.value)
-            case .error(_):
+            case .error:
                 break
             }
         }

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/TransactionsLoadingHandler.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/TransactionsLoadingHandler.swift
@@ -142,7 +142,7 @@ class TransactionsLoadingHandler {
             }.map { (transaction, _, _) -> Transaction in
                 return transaction
             }
-            undecryptedTransactions = undecryptedTransactions + newUndecrypted
+            undecryptedTransactions += newUndecrypted
         }
         
         let remoteTransactionsVM: [TransactionViewModel] = filteredRawTransactions.map {

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -13,8 +13,8 @@ class AccountViewModel: Hashable {
     var address: String
     var name: String
     var totalName: String
-    var totalAmount: String //total amount = public + everything decrypted from shielded
-    var generalAmount: String //public balance
+    var totalAmount: String // total amount = public + everything decrypted from shielded
+    var generalAmount: String // public balance
     var totalLockStatus: ShieldedAccountEncryptionStatus
     
     var owner: String?
@@ -61,12 +61,12 @@ class AccountViewModel: Hashable {
         // TODO: this will need fixing in a future release. We currently don't show the lock
         #warning("RNI: This has been intentionally set to decrypted for the purpose of March 2022 release")
         totalLockStatus = .decrypted
-        //totalLockStatus = (account.encryptedBalanceStatus == ShieldedAccountEncryptionStatus.decrypted) ? .decrypted : .partiallyDecrypted
+        // totalLockStatus = (account.encryptedBalanceStatus == ShieldedAccountEncryptionStatus.decrypted) ? .decrypted : .partiallyDecrypted
         
         atDisposalName = "accounts.atdisposal".localized
         
         if !createMode {
-            areActionsEnabled = !account.isReadOnly //actions are enabled if the account is not readonly
+            areActionsEnabled = !account.isReadOnly // actions are enabled if the account is not readonly
             if totalLockStatus != .decrypted {
                 totalAmount += " + "
             }
@@ -230,17 +230,18 @@ class AccountsPresenter: AccountsPresenterProtocol {
                 self.viewModel.accounts = self.createAccountViewModelWithUpdatedStatus(accounts: updatedAccounts)
 
                 let totalBalance = updatedAccounts.reduce(into: 0, { $0 = $0 + $1.forecastBalance })
-                let atDisposal = updatedAccounts.filter{!$0.isReadOnly}.reduce(into: 0, { $0 = $0 + $1.forecastAtDisposalBalance })
+                let atDisposal = updatedAccounts.filter {!$0.isReadOnly}.reduce(into: 0, { $0 = $0 + $1.forecastAtDisposalBalance })
                 let staked = updatedAccounts.reduce(into: 0, { $0 = $0 + $1.stakedAmount })
                 
 //                let countLocked = updatedAccounts.filter { $0.encryptedBalanceStatus != ShieldedAccountEncryptionStatus.decrypted }.count
 //                self.viewModel.totalBalanceLockStatus = countLocked > 0 ? .encrypted : .decrypted
-                //we add to the alert list all the non read-only accounts that have something in the shielded balance, but do not show a shielded balance 
+                // we add to the alert list all the non read-only accounts that have something in the shielded balance,
+                // but do not show a shielded balance
                 let accountsWithPendingShieldedTransactions = updatedAccounts.filter { account in
                     (account.hasShieldedTransactions && !account.showsShieldedBalance && !account.isReadOnly)
                 }
                 for account in accountsWithPendingShieldedTransactions {
-                    //we add the alert in the queue (the queue knows whether it needs to show it and when)
+                    // we add the alert in the queue (the queue knows whether it needs to show it and when)
                     self.alertDisplayer.enqueueAlert(.shieldedTransfer(account: account, actionCompletion: { [weak self] in
                         self?.delegate?.enableShielded(on: account)
                     }, dismissCompletion: {}))
@@ -380,7 +381,7 @@ class AccountsPresenter: AccountsPresenterProtocol {
             if let account = dependencyProvider.storageManager().getAccounts(for: identity).first {
                 dependencyProvider.storageManager().removeAccount(account: account)
                 let identityProviderName = identity.identityProviderName ?? ""
-                //if no ip support email is present, we use Concordium's
+                // if no ip support email is present, we use Concordium's
                 let identityProviderSupportEmail = identity.identityProvider?.support ?? AppConstants.Support.concordiumSupportMail
                 view?.showIdentityFailed(identityProviderName: identityProviderName,
                                          identityProviderSupport: identityProviderSupportEmail,

--- a/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
@@ -71,14 +71,14 @@ class SendFundViewModel {
     private func setBalancesFor(transferType: TransferType, account: AccountDataType) {
         switch transferType {
         case .simpleTransfer, .transferToSecret:
-            //for transfers from the public account, we show Total and at disposal for the public balance
+            // for transfers from the public account, we show Total and at disposal for the public balance
             firstBalanceName = "sendFund.total".localized
             secondBalanceName = "sendFund.atDisposal".localized
             firstBalance = GTU(intValue: account.forecastBalance).displayValueWithGStroke()
             secondBalance = GTU(intValue: account.forecastAtDisposalBalance).displayValueWithGStroke()
             disposalAmount = GTU(intValue: account.forecastAtDisposalBalance)
         case .encryptedTransfer, .transferToPublic:
-            //for transfers from the shielded account we should the public at disposal and the shielded balance
+            // for transfers from the shielded account we should the public at disposal and the shielded balance
             let showLock = account.encryptedBalanceStatus == .partiallyDecrypted || account.encryptedBalanceStatus == .encrypted
             showShieldedLock = showLock
             firstBalanceName = "sendFund.balanceAtDisposal".localized
@@ -217,7 +217,7 @@ class SendFundPresenter: SendFundPresenterProtocol {
             .map { [weak self] (recipientAddress, feeMessage, amount) in
                 guard let self = self else { return false }
                 guard let recipientAddress = recipientAddress else { return false }
-                let isAddressValid: Bool = (!recipientAddress.isEmpty) && self.dependencyProvider.mobileWallet().check(accountAddress: recipientAddress)
+                let isAddressValid = !recipientAddress.isEmpty && self.dependencyProvider.mobileWallet().check(accountAddress: recipientAddress)
                
                 return isAddressValid &&
                        !(feeMessage ?? "").isEmpty &&
@@ -388,8 +388,8 @@ class SendFundPresenter: SendFundPresenterProtocol {
                 let cost = Int(value.cost) ?? 0
                 let totalAmount: String!
                 if self.balanceType == .shielded {
-                    //the cost is always deducted from the public balance, not
-                    //from the shielded
+                    // the cost is always deducted from the public balance, not
+                    // from the shielded
                     totalAmount = GTU(intValue: disposalAmount).displayValue()
                 } else {
                     totalAmount = GTU(intValue: disposalAmount - cost).displayValue()

--- a/ConcordiumWallet/Views/Identities/CreateIdentity/IdentityProviderList/IdentityProviderListPresenter.swift
+++ b/ConcordiumWallet/Views/Identities/CreateIdentity/IdentityProviderList/IdentityProviderListPresenter.swift
@@ -20,7 +20,15 @@ class IdentityGeneralViewModel: Hashable {
     var privacyPolicyURL: String
     var url: String?
 
-    init(id: Int, identityName: String, iconEncoded: String, privacyPolicyURL: String?, nickname: String? = nil, expiresOn: String? = nil, url: String?) {
+    init(
+        id: Int,
+        identityName: String,
+        iconEncoded: String,
+        privacyPolicyURL: String?,
+        nickname: String? = nil,
+        expiresOn: String? = nil,
+        url: String?
+    ) {
         self.id = id
         self.identityName = identityName
         self.nickname = nickname ?? ""

--- a/ConcordiumWallet/Views/Identities/IdentitiesCoordinator.swift
+++ b/ConcordiumWallet/Views/Identities/IdentitiesCoordinator.swift
@@ -82,7 +82,7 @@ class IdentitiesCoordinator: Coordinator {
                 vc.secondaryBottomWidget = ContactSupportButtonWidgetFactory.create(with: contactSupportButtonWidgetPresenter)
             } else {
                 let identityProviderName = identity.identityProviderName ?? ""
-                //if no ip support email is present, we use Concordium's
+                // if no ip support email is present, we use Concordium's
                 let identityProviderSupportEmail = identity.identityProvider?.support ?? AppConstants.Support.concordiumSupportMail
                 let copyReferenceInfoWidgetPresenter = CopyReferenceInfoWidgetPresenter(identityProviderName: identityProviderName,
                                                                                         identityProviderSupportEmail: identityProviderSupportEmail)

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
@@ -92,6 +92,18 @@ class IdentitiesPresenter: IdentityGeneralPresenter {
     }
 
     override func createIdentitySelected() {
+        guard !identities.contains(where: { $0.state == .pending }) else {
+            view?.showAlert(with: AlertOptions(
+                title: "identityCreation.hasPending".localized, 
+                message: "identityCreation.hasPending.message".localized,
+                actions: [
+                    AlertAction(name: "OK".localized, completion: nil, style: .default)
+                ]
+            ))
+            
+            return
+        }
+        
         self.delegate?.createIdentitySelected()
     }
 

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
@@ -73,7 +73,7 @@ class IdentitiesPresenter: IdentityGeneralPresenter {
             if let account = dependencyProvider.storageManager().getAccounts(for: identity).first {
                 dependencyProvider.storageManager().removeAccount(account: account)
                 let identityProviderName = identity.identityProviderName ?? ""
-                //if no ip support email is present, we use Concordium's
+                // if no ip support email is present, we use Concordium's
                 let identityProviderSupport = identity.identityProvider?.support ?? AppConstants.Support.concordiumSupportMail
                 view?.showIdentityFailed(identityProviderName: identityProviderName,
                                          identityProviderSupportEmail: identityProviderSupport,
@@ -82,7 +82,7 @@ class IdentitiesPresenter: IdentityGeneralPresenter {
                     case .tryAgain:
                         self?.delegate?.tryAgainIdentity()
                     case .support, .copy, .cancel:
-                        //no need to refresh because the identities are not updated
+                        // no need to refresh because the identities are not updated
                         break
                     }
                 }

--- a/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
+++ b/ConcordiumWallet/Views/Identities/IdentityList/IdentitiesPresenter.swift
@@ -94,8 +94,8 @@ class IdentitiesPresenter: IdentityGeneralPresenter {
     override func createIdentitySelected() {
         guard !identities.contains(where: { $0.state == .pending }) else {
             view?.showAlert(with: AlertOptions(
-                title: "identityCreation.hasPending".localized, 
-                message: "identityCreation.hasPending.message".localized,
+                title: nil,
+                message: "identityCreation.hasPending".localized,
                 actions: [
                     AlertAction(name: "OK".localized, completion: nil, style: .default)
                 ]

--- a/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
+++ b/ConcordiumWallet/Views/Login/PasswordViews/LoginPresenter.swift
@@ -42,7 +42,7 @@ class LoginPresenter: EnterPasswordPresenterProtocol {
                 .onSuccess { pwHash in
                     let passwordCheck = dependencyProvider.keychainWrapper()
                             .checkPasswordHash(pwHash: pwHash)
-                    _ = sanityChecker.generateSanityReport(pwHash: pwHash) //we just make the sanitary report
+                    _ = sanityChecker.generateSanityReport(pwHash: pwHash) // we just make the sanitary report
                     handlePasswordCheck(checkPassword: passwordCheck)
                 }
         }

--- a/ConcordiumWallet/Views/Login/TermsAndConditionsView/TermsAndConditionsPresenter.swift
+++ b/ConcordiumWallet/Views/Login/TermsAndConditionsView/TermsAndConditionsPresenter.swift
@@ -33,7 +33,7 @@ class TermsAndConditionsPresenter {
 
 extension TermsAndConditionsPresenter: TermsAndConditionsPresenterProtocol {
     func userTappedAcceptTerms() {
-        //save the hash of the accepted terms
+        // save the hash of the accepted terms
         AppSettings.acceptedTermsHash = HashingHelper.hash(TermsHelper.currentTerms)
         self.delegate?.userTappedAcceptTerms()
     }

--- a/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
+++ b/ConcordiumWallet/Views/MoreSection/Import/IdentityImporter.swift
@@ -20,9 +20,9 @@ class IdentityImporter {
                         importReport: inout ImportedItemsReport) -> IdentityDataType? {
         do {
             if let existingEntity = storageManager.getIdentity(matching: identityDataToImport.identityObject) {
-                //Here we have an identity stored.
-                //We check whether the identity has its keys and if it does, we try to
-                //import its accounts and mark it as duplicate in the report
+                // Here we have an identity stored.
+                // We check whether the identity has its keys and if it does, we try to
+                // import its accounts and mark it as duplicate in the report
                
                 if let key = existingEntity.encryptedPrivateIdObjectData,
                    (try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()) != nil {
@@ -31,7 +31,7 @@ class IdentityImporter {
                     importReport.duplicateIdentities.append(importedIdentity)
                     return existingEntity
                 } else {
-                    //we delete the stored unusable identity
+                    // we delete the stored unusable identity
                     storageManager.removeIdentity(existingEntity)
                 }
             }
@@ -79,7 +79,7 @@ class IdentityImporter {
         if let storedAccount = existingAccount,
             let key = storedAccount.encryptedPrivateKey,
            (try? storageManager.getPrivateIdObjectData(key: key, pwHash: pwHash).get()) != nil {
-            //if the privateIdObject is NOT nil, it means the account contains keys
+            // if the privateIdObject is NOT nil, it means the account contains keys
             accountContainsKeys = true
         } else {
             accountContainsKeys = false
@@ -125,7 +125,7 @@ class IdentityImporter {
     private func importReadOnlyAccount(_ readOnlyAccount: MakeGenerateAccountsResponseElement, relatedIdentity: IdentityDataType, pwHash: String) {
         let existingAccount = storageManager.getAccount(withAddress: readOnlyAccount.accountAddress)
         guard existingAccount == nil else {
-            //we don't import a read-only account if the account is already saved locally
+            // we don't import a read-only account if the account is already saved locally
             return
         }
         do {

--- a/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
@@ -10,16 +10,18 @@ import Combine
 protocol MoreCoordinatorDelegate: IdentitiesCoordinatorDelegate { }
 
 class MoreCoordinator: Coordinator, ShowAlert {
+    typealias DependencyProvider = MoreFlowCoordinatorDependencyProvider & IdentitiesFlowCoordinatorDependencyProvider
+    
     var childCoordinators = [Coordinator]()
     var navigationController: UINavigationController
-    private var dependencyProvider: MoreFlowCoordinatorDependencyProvider & IdentitiesFlowCoordinatorDependencyProvider
+    private var dependencyProvider: DependencyProvider
     private var loginDependencyProvider: LoginDependencyProvider
     private var sanityChecker: SanityChecker
     
     weak var delegate: MoreCoordinatorDelegate?
     
     init(navigationController: UINavigationController,
-         dependencyProvider: IdentitiesFlowCoordinatorDependencyProvider & MoreFlowCoordinatorDependencyProvider & LoginDependencyProvider & WalletAndStorageDependencyProvider,
+         dependencyProvider: DependencyProvider & LoginDependencyProvider & WalletAndStorageDependencyProvider,
          parentCoordinator: MoreCoordinatorDelegate) {
         self.navigationController = navigationController
         self.dependencyProvider = dependencyProvider

--- a/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
+++ b/ConcordiumWallet/Views/MoreSection/VerifyIdsAndAccounts/SanityChecker.swift
@@ -145,7 +145,7 @@ class SanityChecker {
     private func removeIdentitiesAndAccountsWithoutKeys(report: [(IdentityDataType?, [AccountDataType])]) -> [IdentityDataType] {
         var failToRemoveIdentities = [IdentityDataType]()
         for (identity, accounts) in report {
-            //if we do not have an identity attached, we delete the accounts
+            // if we do not have an identity attached, we delete the accounts
             guard let identity = identity else {
                 for account in accounts {
                     self.storageManager.removeAccount(account: account)
@@ -156,7 +156,7 @@ class SanityChecker {
             for account in accounts {
                 self.storageManager.removeAccount(account: account)
             }
-            //if the identity contains also valid accounts, we cannot delete the identity
+            // if the identity contains also valid accounts, we cannot delete the identity
             if identityAccounts.count == accounts.count {
                 self.storageManager.removeIdentity(identity)
             } else {
@@ -177,7 +177,7 @@ class SanityChecker {
     }
     
     private func markIdsAndAccountsAsReadOnly(report: [(IdentityDataType?, [AccountDataType])]) {
-        //only accounts will be marked as readonly because we don't have a readonly state for ids yet
+        // only accounts will be marked as readonly because we don't have a readonly state for ids yet
         for (_, accounts) in report {
             for account in accounts {
                 _ = account.withMarkAsReadOnly(true)

--- a/ConcordiumWallet/Views/RootView/MainTabBarController.swift
+++ b/ConcordiumWallet/Views/RootView/MainTabBarController.swift
@@ -16,8 +16,8 @@ class MainTabBarController: BaseTabBarController {
     // Override selectedViewController for User initiated changes
     override var selectedViewController: UIViewController? {
         didSet {
-            //if the selectedViewController is not a navigationController, it means it is the export tab
-            //switch to the morecoordinator and display the export screen
+            // if the selectedViewController is not a navigationController, it means it is the export tab
+            // switch to the morecoordinator and display the export screen
             if !(selectedViewController is UINavigationController) {
                 selectedViewController = moreCoordinator.navigationController
                 moreCoordinator.showExport()
@@ -43,7 +43,7 @@ class MainTabBarController: BaseTabBarController {
         accountsCoordinator.delegate = self
         accountsCoordinator.start()
        
-        let exportVC = UIViewController() //this will never be shown - we just use it to have a tab
+        let exportVC = UIViewController() // this will never be shown - we just use it to have a tab
         exportVC.tabBarItem = UITabBarItem(title: "backup_tab_title".localized, image: UIImage(named: "tab_bar_backup_icon"), tag: 0)
         moreCoordinator.start()
         viewControllers = [exportVC, accountsCoordinator.navigationController, moreCoordinator.navigationController]

--- a/ConcordiumWallet/Views/Widgets/ContactSupportButtonWidgetPresenter.swift
+++ b/ConcordiumWallet/Views/Widgets/ContactSupportButtonWidgetPresenter.swift
@@ -38,7 +38,7 @@ class ContactSupportButtonWidgetPresenter: ContactSupportButtonWidgetPresenterPr
     
     func contactSupportButtonTapped() {
         guard let reference = identity.hashedIpStatusUrl else { return }
-        //if no ip support email is present, we use Concordium's
+        // if no ip support email is present, we use Concordium's
         let supportEmail = identity.identityProvider?.support ?? AppConstants.Support.concordiumSupportMail
         view?.launchSupport(to: supportEmail, with: reference)
         delegate?.contactSupportButtonWidgetDidContactSupport()

--- a/ioscommon/Commons/Publisher+Utils.swift
+++ b/ioscommon/Commons/Publisher+Utils.swift
@@ -49,7 +49,7 @@ extension Publisher {
 
     static func just(_ output: Output) -> AnyPublisher<Output, Failure> {
         return Just(output)
-                .catch { _ in AnyPublisher<Output, Failure>.empty() }
+            	.setFailureType(to: Failure.self)
                 .eraseToAnyPublisher()
     }
 

--- a/ioscommon/Commons/Validator.swift
+++ b/ioscommon/Commons/Validator.swift
@@ -34,7 +34,6 @@ private struct MemoSizeValidator {
     }
 }
 
-
 // MARK: - Name Length Validator
 
 private struct NameLengthValidator {


### PR DESCRIPTION
## Purpose

This PR fixes an issue where an error dialog is not shown when an identity issuance fails. 

## Changes

As described in the issue the solution is to only allow one pending identity issuance at a time.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
