### PR TITLE
align camera permissions checks

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
@@ -274,7 +274,22 @@ class SendFundPresenter: SendFundPresenterProtocol {
     }
     
     func userTappedScanQR() {
-        delegate?.sendFundPresenterShowScanQRCode(delegate: self)
+        PermissionHelper.requestAccess(for: .camera) { [weak self] permissionGranted in
+            guard let self = self else { return }
+            
+            guard permissionGranted else {
+                self.view?.showRecoverableErrorAlert(
+                    .cameraAccessDeniedError,
+                    recoverActionTitle: "errorAlert.continueButton".localized,
+                    hasCancel: true
+                ) {
+                    SettingsHelper.openAppSettings()
+                }
+                return
+            }
+
+            self.delegate?.sendFundPresenterShowScanQRCode(delegate: self)
+        }
     }
     
     func setSelectedRecipient(recipient: RecipientDataType) {

--- a/ioscommon/Commons/PermissionHelper.swift
+++ b/ioscommon/Commons/PermissionHelper.swift
@@ -26,7 +26,9 @@ struct PermissionHelper {
                 completionHandler(false)
             case .restricted, .notDetermined:
                 AVCaptureDevice.requestAccess(for: .video) { granted in
-                    completionHandler(granted)
+                    DispatchQueue.main.async {
+                        completionHandler(granted)
+                    }
                 }
             default:
                 return


### PR DESCRIPTION
## Purpose

Scan QR on send funds should also check for camera permissions. 

## Changes

Implemented a check for camera permission before showing the QR scanner. Also ensure that completion handlers are dispatched to the main thread from the permission callback.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
