### PR TITLE
implement waring when a baker pool is closing

### DIFF
--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -619,6 +619,14 @@ Do you want to remove your delegation?";
 "delegation.nochanges.message" = "Your transaction contains no changes compared to the current delegation.";
 "delegation.nochanges.ok" = "Okay";
 
+"delegation.closewarning.title" = "Delegation update";
+"delegation.closewarning.message" = "The target pools of the following accounts will close soon. If you don’t actively change the target pool, your account will keep earning rewards as a passive delegator after the cooldown.
+
+You can however already change your target pool via the delegation status menu, if you would rather do that.
+
+Affected delegator accounts:\n%@";
+"delegation.closewarning.remindmeaction" = "Remind me next time I open the wallet";
+
 "baker.receiptconfirmation.title.update" = "Update baker stake";
 "baker.receiptconfirmation.loweringstake" = "You are about to submit a transaction that lowers your baker stake. Lowering your stake has a cooldown period, meaning it will not take effect immediately.
 


### PR DESCRIPTION
## Purpose

The user should be presented with a warning if a baker pool they are delegating to is closing.

## Changes

A warning is now presented to the user on startup if one or more of their accounts are delegating to a closing pool.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
