### PR TITLE
Fix/enforce delegation pool size on update

### DIFF
--- a/ConcordiumWallet/Presentation/GTU.swift
+++ b/ConcordiumWallet/Presentation/GTU.swift
@@ -102,3 +102,9 @@ extension GTU: Hashable {
         lhs.intValue == rhs.intValue
     }
 }
+
+extension GTU: Comparable {
+    static func < (lhs: GTU, rhs: GTU) -> Bool {
+        lhs.intValue < rhs.intValue
+    }
+}

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -515,6 +515,7 @@ concordium-backup.concordiumwallet securely.";
 "stake.inputAmount.error.maxAmount" = "Current maximum:  %@";
 "stake.inputAmount.error.funds" = "Not enough funds";
 "stake.inputAmount.error.poolLimit" = "Pool limit will be breached";
+"stake.inputAmount.error.amountTooLarge" = "Your delegation amount is too large for this pool";
 "stake.inputAmount.amountlockedplaceholder" = "Amount locked";
 "stake.inputAmount.amountplaceholder" = "Ͼ0.00";
 

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -551,6 +551,12 @@ developer.concordium.software";
 "delegation.pool.invalidbakerid" = "Invalid target baker pool ID";
 "delegation.pool.closedpool" = "This pool is closed";
 
+"delegation.pool.sizewarning.title" = "Current delegation amount too large";
+"delegation.pool.sizewarning.message" = "Your current delegation amount will breach the new pool’s limits. To delegate to this pool you must first lower or stop your delegation and then wait for the cool down to pass.";
+"delegation.pool.sizewarning.loweramount" = "Lower delegation amount and stay with current pool";
+"delegation.pool.sizewarning.stopdelegation" = "Stop current delegation";
+"delegation.pool.sizewarning.cancel" = "Cancel";
+
 "delegation.receipt.accounttodelegate" = "Account to delegate from";
 "delegation.receipt.accounttostop" = "Account to stop delegating";
 "delegation.receipt.delegationamount" = "Delegation amount";

--- a/ConcordiumWallet/Views/Stake/Common/AmountInput/StakeAmountInputPresenterProtocol.swift
+++ b/ConcordiumWallet/Views/Stake/Common/AmountInput/StakeAmountInputPresenterProtocol.swift
@@ -14,6 +14,7 @@ enum StakeError: Error {
     case notEnoughFund(GTU)
     case poolLimitReached(GTU, GTU)
     case feeError
+    case amountTooLarge(GTU, GTU)
     case internalError
     
     var localizedDescription: String {
@@ -26,6 +27,8 @@ enum StakeError: Error {
             return "stake.inputAmount.error.funds".localized
         case .poolLimitReached:
             return "stake.inputAmount.error.poolLimit".localized
+        case .amountTooLarge:
+            return "stake.inputAmount.error.amountTooLarge".localized
         case .internalError:
             return ""
         case .feeError:
@@ -37,13 +40,14 @@ enum StakeError: Error {
 struct BalanceViewModel {
     var label: String
     var value: String
+    var hightlighted: Bool
 }
 
 class StakeAmountInputViewModel {
     @Published var title: String = ""
     
-    @Published var firstBalance: BalanceViewModel = BalanceViewModel(label: "", value: "")
-    @Published var secondBalance: BalanceViewModel = BalanceViewModel(label: "", value: "")
+    @Published var firstBalance: BalanceViewModel = BalanceViewModel(label: "", value: "", hightlighted: false)
+    @Published var secondBalance: BalanceViewModel = BalanceViewModel(label: "", value: "", hightlighted: false)
 
     @Published var amountMessage: String = ""
     @Published var amount: String = ""
@@ -52,8 +56,8 @@ class StakeAmountInputViewModel {
     @Published var transactionFee: String? = ""
     
     @Published var showsPoolLimits: Bool = false
-    @Published var currentPoolLimit: BalanceViewModel? = BalanceViewModel(label: "", value: "")
-    @Published var poolLimit: BalanceViewModel? = BalanceViewModel(label: "", value: "")
+    @Published var currentPoolLimit: BalanceViewModel? = BalanceViewModel(label: "", value: "", hightlighted: false)
+    @Published var poolLimit: BalanceViewModel? = BalanceViewModel(label: "", value: "", hightlighted: false)
     
     @Published var isRestakeSelected: Bool = true
     

--- a/ConcordiumWallet/Views/Stake/Common/AmountInput/StakeAmountInputViewController.swift
+++ b/ConcordiumWallet/Views/Stake/Common/AmountInput/StakeAmountInputViewController.swift
@@ -109,12 +109,14 @@ class StakeAmountInputViewController: KeyboardDismissableBaseViewController, Sta
         viewModel.$firstBalance.sink { [weak self] balanceVM in
             guard let self = self else { return }
             self.firstBalanceLabel.text = balanceVM.label
+            self.firstBalanceLabel.textColor = balanceVM.hightlighted ? .errorText : .text
             self.firstBalanceValue.text = balanceVM.value
         }.store(in: &cancellables)
         
         viewModel.$secondBalance.sink { [weak self] balanceVM in
             guard let self = self else { return }
             self.secondBalanceLabel.text = balanceVM.label
+            self.secondBalanceLabel.textColor = balanceVM.hightlighted ? .errorText : .text
             self.secondBalanceValue.text = balanceVM.value
         }.store(in: &cancellables)
         
@@ -127,6 +129,7 @@ class StakeAmountInputViewController: KeyboardDismissableBaseViewController, Sta
             guard let self = self else { return }
             guard let balanceVM = balanceVM else { return }
             self.thirdBalanceLabel.text = balanceVM.label
+            self.thirdBalanceLabel.textColor = balanceVM.hightlighted ? .errorText : .text
             self.thirdBalanceValue.text = balanceVM.value
         }.store(in: &cancellables)
         
@@ -134,6 +137,7 @@ class StakeAmountInputViewController: KeyboardDismissableBaseViewController, Sta
             guard let self = self else { return }
             guard let balanceVM = balanceVM else { return }
             self.fourthBalanceLabel.text = balanceVM.label
+            self.fourthBalanceLabel.textColor = balanceVM.hightlighted ? .errorText : .text
             self.fourthBalanceValue.text = balanceVM.value
         }.store(in: &cancellables)
         

--- a/ConcordiumWallet/Views/Stake/Delegation/DelegationCoordinator.swift
+++ b/ConcordiumWallet/Views/Stake/Delegation/DelegationCoordinator.swift
@@ -85,7 +85,12 @@ class DelegationCoordinator: Coordinator {
     }
     
     func showPoolSelection() {
-        let presenter = DelegationPoolSelectionPresenter(delegate: self, dependencyProvider: dependencyProvider, dataHandler: delegationDataHandler)
+        let presenter = DelegationPoolSelectionPresenter(
+            account: account,
+            delegate: self,
+            dependencyProvider: dependencyProvider,
+            dataHandler: delegationDataHandler
+        )
         let vc = DelegationPoolSelectionFactory.create(with: presenter)
         navigationController.pushViewController(vc, animated: true)
     }

--- a/ConcordiumWallet/Views/Stake/Delegation/PoolSelection/DelegationPoolSelectionPresenter.swift
+++ b/ConcordiumWallet/Views/Stake/Delegation/PoolSelection/DelegationPoolSelectionPresenter.swift
@@ -188,7 +188,6 @@ class DelegationPoolSelectionPresenter: DelegationPoolSelectionPresenterProtocol
         // the pool will be valid at this point as the buttonn is only enabled
         // if the pool is valid
         guard let validPool = self.validSelectedPool else { return }
-        self.dataHandler.add(entry: PoolDelegationData(pool: validPool))
         
         if case .bakerPool(let bakerId) = validPool {
             // we use whichever is available first, either the variable or
@@ -205,11 +204,13 @@ class DelegationPoolSelectionPresenter: DelegationPoolSelectionPresenterProtocol
                     if self.shouldShowPoolSizeWarning(response: bakerPoolResponse) {
                         self.showPoolSizeWarning(response: bakerPoolResponse)
                     } else {
+                        self.dataHandler.add(entry: PoolDelegationData(pool: validPool))
                         self.delegate?.finishedPoolSelection(bakerPoolResponse: bakerPoolResponse)
                     }
                 })
                 .store(in: &cancellables)
         } else {
+            self.dataHandler.add(entry: PoolDelegationData(pool: validPool))
             self.delegate?.finishedPoolSelection(bakerPoolResponse: nil)
         }
     }


### PR DESCRIPTION
## Purpose

If a baker pool does not have sufficient capacity for your current stake, you should receive a warning when switching to it.

## Changes

Depending on your cooldown status, we either show a warning before the amount screen or we simply flag it on the amount screen itself.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
