### PR TITLE
changed references to l-pool to passive

### DIFF
--- a/ConcordiumWallet.xcodeproj/project.pbxproj
+++ b/ConcordiumWallet.xcodeproj/project.pbxproj
@@ -1507,6 +1507,10 @@
 		7FF9191D2511505C00B1032B /* ImportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF919172511505B00B1032B /* ImportViewController.swift */; };
 		7FF9191E2511505C00B1032B /* ImportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF919172511505B00B1032B /* ImportViewController.swift */; };
 		7FF9191F2511505C00B1032B /* ImportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF919172511505B00B1032B /* ImportViewController.swift */; };
+		89CF2D4E281945F200742E1E /* ChainParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CF2D4D281945F200742E1E /* ChainParametersResponse.swift */; };
+		89CF2D4F281945F200742E1E /* ChainParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CF2D4D281945F200742E1E /* ChainParametersResponse.swift */; };
+		89CF2D50281945F200742E1E /* ChainParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CF2D4D281945F200742E1E /* ChainParametersResponse.swift */; };
+		89CF2D51281945F200742E1E /* ChainParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CF2D4D281945F200742E1E /* ChainParametersResponse.swift */; };
 		901F7EEA27E8A6A600C46741 /* BakerKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7EE827E8A6A600C46741 /* BakerKeys.swift */; };
 		901F7EEB27E8A6A600C46741 /* BakerKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7EE827E8A6A600C46741 /* BakerKeys.swift */; };
 		901F7EEC27E8A6A600C46741 /* BakerKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7EE827E8A6A600C46741 /* BakerKeys.swift */; };
@@ -1547,14 +1551,10 @@
 		901F7F1927EA0F1B00C46741 /* CommissionRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7F1527EA0F1A00C46741 /* CommissionRange.swift */; };
 		901F7F1A27EA0F1B00C46741 /* CommissionRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7F1527EA0F1A00C46741 /* CommissionRange.swift */; };
 		901F7F1B27EA0F1B00C46741 /* CommissionRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7F1527EA0F1A00C46741 /* CommissionRange.swift */; };
-		901F7F1C27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7F1627EA0F1B00C46741 /* PoolParametersResponse.swift */; };
-		901F7F1D27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7F1627EA0F1B00C46741 /* PoolParametersResponse.swift */; };
-		901F7F1E27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7F1627EA0F1B00C46741 /* PoolParametersResponse.swift */; };
-		901F7F1F27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901F7F1627EA0F1B00C46741 /* PoolParametersResponse.swift */; };
-		901F7F2627EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json */; };
-		901F7F2727EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json */; };
-		901F7F2827EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json */; };
-		901F7F2927EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json */; };
+		901F7F2627EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json */; };
+		901F7F2727EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json */; };
+		901F7F2827EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json */; };
+		901F7F2927EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2427EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json */; };
 		901F7F2A27EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2527EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json */; };
 		901F7F2B27EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2527EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json */; };
 		901F7F2C27EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json in Resources */ = {isa = PBXBuildFile; fileRef = 901F7F2527EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json */; };
@@ -2236,6 +2236,7 @@
 		7FF9190C250E4EAD00B1032B /* ImportStatusCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImportStatusCell.xib; sourceTree = "<group>"; };
 		7FF91911250E571900B1032B /* ImportStatusCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportStatusCell.swift; sourceTree = "<group>"; };
 		7FF919172511505B00B1032B /* ImportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportViewController.swift; sourceTree = "<group>"; };
+		89CF2D4D281945F200742E1E /* ChainParametersResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChainParametersResponse.swift; sourceTree = "<group>"; };
 		901F7EE827E8A6A600C46741 /* BakerKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BakerKeys.swift; sourceTree = "<group>"; };
 		901F7EE927E8A6A600C46741 /* DelegationTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegationTarget.swift; sourceTree = "<group>"; };
 		901F7EF227E9D98C00C46741 /* TransferCostParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferCostParameters.swift; sourceTree = "<group>"; };
@@ -2246,8 +2247,7 @@
 		901F7EFF27EA0D5C00C46741 /* CurrentPaydayStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentPaydayStatus.swift; sourceTree = "<group>"; };
 		901F7F0027EA0D5C00C46741 /* PoolInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoolInfo.swift; sourceTree = "<group>"; };
 		901F7F1527EA0F1A00C46741 /* CommissionRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommissionRange.swift; sourceTree = "<group>"; };
-		901F7F1627EA0F1B00C46741 /* PoolParametersResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoolParametersResponse.swift; sourceTree = "<group>"; };
-		901F7F2427EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 5.2.2.RX_backend_pool_parameters.json; sourceTree = "<group>"; };
+		901F7F2427EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 5.2.2.RX_backend_chain_parameters.json; sourceTree = "<group>"; };
 		901F7F2527EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 5.1.2.RX_backend_baker_pool.json; sourceTree = "<group>"; };
 		901F7F2E27EB023100C46741 /* AccountDelegation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountDelegation.swift; sourceTree = "<group>"; };
 		901F7F3827EB07AE00C46741 /* BakerEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BakerEntity.swift; sourceTree = "<group>"; };
@@ -2752,7 +2752,6 @@
 				901F7F9027F33C8800C46741 /* TransactionFeeDistribution.swift */,
 				901F7F2E27EB023100C46741 /* AccountDelegation.swift */,
 				901F7F1527EA0F1A00C46741 /* CommissionRange.swift */,
-				901F7F1627EA0F1B00C46741 /* PoolParametersResponse.swift */,
 				901F7EFE27EA0D5C00C46741 /* BakerPoolResponse.swift */,
 				901F7EFD27EA0D5C00C46741 /* BakerStakePendingChange.swift */,
 				901F7EFC27EA0D5C00C46741 /* CommissionRates.swift */,
@@ -2773,6 +2772,7 @@
 				5211BAA224FD1D5100EE1658 /* Balance.swift */,
 				19C2EFF2620E0CD7DECE642A /* ChoiceArData.swift */,
 				07DEC16A26F0D5590094395E /* CommitmentsRandomness.swift */,
+				89CF2D4D281945F200742E1E /* ChainParametersResponse.swift */,
 				7F21397724236C0A00D2A5C4 /* CreateCredentialRequest.swift */,
 				19C2EC8269ACB6C892A16310 /* CreateIDRequest.swift */,
 				7FF618EC2437294E00269F9F /* CreateTransferRequest.swift */,
@@ -3160,7 +3160,7 @@
 				5237186A25751F2000B2BC31 /* 4.5.1.TX_lib_generate_accounts.json */,
 				5237186925751F2000B2BC31 /* 4.5.2.RX_lib_generate_accounts.json */,
 				901F7F2527EA138300C46741 /* 5.1.2.RX_backend_baker_pool.json */,
-				901F7F2427EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json */,
+				901F7F2427EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json */,
 				19C2E15DA745EE0E2755FFAE /* backend_invalidRequest_error.json */,
 				7FA0AEA6246061A500B7673F /* backend_server_error.json */,
 				7F48C252244DCEF700997684 /* NetworkSessionMock.swift */,
@@ -3972,7 +3972,7 @@
 				52055F9A25541B160071F7CA /* AccountCardView.xib in Resources */,
 				90434C7E27FB111B00E4DBAA /* delegation_update_flow_en_3.html in Resources */,
 				7F48C20A244DCD0B00997684 /* .swiftlint.yml in Resources */,
-				901F7F2627EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */,
+				901F7F2627EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */,
 				7F48C24E244DCD7100997684 /* 2.3.1.TX_backend_submitCredential.json in Resources */,
 				901F7F7C27F1D5DE00C46741 /* delegation_intro_flow_en_3.html in Resources */,
 				070D625027B3DD5600B6903C /* unshielding_1.svg in Resources */,
@@ -4081,7 +4081,7 @@
 				07E6E27827B558A30083A852 /* intro_flow_onboarding_en_5.html in Resources */,
 				07E6E28027B558A30083A852 /* intro_flow_onboarding_en_3.html in Resources */,
 				90434C8427FB111B00E4DBAA /* delegation_update_flow_en_1.html in Resources */,
-				901F7F2827EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */,
+				901F7F2827EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */,
 				52055F9C25541B160071F7CA /* AccountCardView.xib in Resources */,
 				070D622727B3C54600B6903C /* shielded_balance_onboarding_en_5.html in Resources */,
 			);
@@ -4119,7 +4119,7 @@
 				90434C7127FB108D00E4DBAA /* delegation_remove_flow_en_2.html in Resources */,
 				070D626A27B40C2D00B6903C /* Onboarding.storyboard in Resources */,
 				070D622427B3C54600B6903C /* shielded_balance_onboarding_en_4.html in Resources */,
-				901F7F2927EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */,
+				901F7F2927EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */,
 				070D622C27B3C54600B6903C /* shielded_balance_onboarding_en_2.html in Resources */,
 				070D625727B3DD5600B6903C /* shielding_2.svg in Resources */,
 				90434CAC27FB2D4200E4DBAA /* removedelegation_flow_style.css in Resources */,
@@ -4183,7 +4183,7 @@
 				070D622E27B3C54600B6903C /* shielded_balance_onboarding_en_3.html in Resources */,
 				07E6E27B27B558A30083A852 /* intro_flow_onboarding_en_4.html in Resources */,
 				90434C6B27FB108D00E4DBAA /* delegation_remove_flow_en_1.html in Resources */,
-				901F7F2727EA138300C46741 /* 5.2.2.RX_backend_pool_parameters.json in Resources */,
+				901F7F2727EA138300C46741 /* 5.2.2.RX_backend_chain_parameters.json in Resources */,
 				7F5F779324891F220016F8D1 /* AppIcon.xcassets in Resources */,
 				52055F9B25541B160071F7CA /* AccountCardView.xib in Resources */,
 				901F7F7D27F1D5DE00C46741 /* delegation_intro_flow_en_3.html in Resources */,
@@ -4610,6 +4610,7 @@
 				7F48C186244DCD0B00997684 /* RoundedCornerView.swift in Sources */,
 				7F48C279244E17D100997684 /* PrivateIDObjectData.swift in Sources */,
 				7F48C188244DCD0B00997684 /* AccountsPresenter.swift in Sources */,
+				89CF2D4E281945F200742E1E /* ChainParametersResponse.swift in Sources */,
 				7F48C25A244E17D100997684 /* IdentityObject.swift in Sources */,
 				90C371D327DF24F00046F05E /* BakerPoolSettingsViewController.swift in Sources */,
 				7F48C18B244DCD0B00997684 /* CreateIdentityCoordinator.swift in Sources */,
@@ -4625,7 +4626,6 @@
 				7F48C192244DCD0B00997684 /* IdentityBaseInfoWidgetViewController.swift in Sources */,
 				90434C8727FB29C600E4DBAA /* DelegationOnboardingCoordinator.swift in Sources */,
 				7F48C283244EEE6500997684 /* TransactionSubmittedPresenter.swift in Sources */,
-				901F7F1C27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */,
 				7F48C195244DCD0B00997684 /* AccountDetailsCoordinator.swift in Sources */,
 				7F48C197244DCD0B00997684 /* ScanAddressQRViewController.swift in Sources */,
 				7FF91912250E571900B1032B /* ImportStatusCell.swift in Sources */,
@@ -5024,6 +5024,7 @@
 				7F85B754246A9A7C00ED09B8 /* NetworkManager.swift in Sources */,
 				7F85B755246A9A7C00ED09B8 /* IdentityInfoViewModel.swift in Sources */,
 				7F85B756246A9A7C00ED09B8 /* ResourceRequest.swift in Sources */,
+				89CF2D50281945F200742E1E /* ChainParametersResponse.swift in Sources */,
 				7F85B757246A9A7C00ED09B8 /* LoginErrorLabel.swift in Sources */,
 				7F85B758246A9A7C00ED09B8 /* NetworkManagerProtocol.swift in Sources */,
 				7F85B759246A9A7C00ED09B8 /* Publisher+Utils.swift in Sources */,
@@ -5188,7 +5189,6 @@
 				52A6A77B24F9066700138D83 /* PrivateIDObjectDataWrapper.swift in Sources */,
 				19C2E6DE2479B8D900DF10E7 /* ExportIdentityData.swift in Sources */,
 				07619A93269D83D9009B79E2 /* AppConstants.swift in Sources */,
-				901F7F1E27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */,
 				529531AB256BA711004CECE4 /* AccountBaker.swift in Sources */,
 				64DB66CB25DE6A1000F4C605 /* AboutPresenter.swift in Sources */,
 				529531BD256BE0A6004CECE4 /* ScheduleEntity.swift in Sources */,
@@ -5411,6 +5411,7 @@
 				7F85B8E82472D37600ED09B8 /* MoreMenuViewController.swift in Sources */,
 				7F85B852246A9AB600ED09B8 /* StorageManager.swift in Sources */,
 				7F85B853246A9AB600ED09B8 /* NetworkManager.swift in Sources */,
+				89CF2D51281945F200742E1E /* ChainParametersResponse.swift in Sources */,
 				7F85B854246A9AB600ED09B8 /* IdentityInfoViewModel.swift in Sources */,
 				7F85B855246A9AB600ED09B8 /* ResourceRequest.swift in Sources */,
 				7F85B856246A9AB600ED09B8 /* LoginErrorLabel.swift in Sources */,
@@ -5575,7 +5576,6 @@
 				52A6A77C24F9066700138D83 /* PrivateIDObjectDataWrapper.swift in Sources */,
 				19C2E8235F5A65E28FB153B6 /* AES256Encryption.swift in Sources */,
 				07619A94269D83D9009B79E2 /* AppConstants.swift in Sources */,
-				901F7F1F27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */,
 				529531AC256BA711004CECE4 /* AccountBaker.swift in Sources */,
 				64DB66D125DE6A1100F4C605 /* AboutPresenter.swift in Sources */,
 				529531BE256BE0A6004CECE4 /* ScheduleEntity.swift in Sources */,
@@ -5753,6 +5753,7 @@
 				7FB4118523F2B031007FE732 /* IdentityBaseInfoWidgetViewController.swift in Sources */,
 				C92C64F8244EE7C500675ECE /* TransferCost.swift in Sources */,
 				7F7F6D3424A09AE90017B18F /* DeleteIdentityButtonWidgetViewController.swift in Sources */,
+				89CF2D4F281945F200742E1E /* ChainParametersResponse.swift in Sources */,
 				C9C097A724331BC400ACA35A /* AccountDetailsCoordinator.swift in Sources */,
 				7FD8DEAA2448623300CA06D8 /* ScanAddressQRViewController.swift in Sources */,
 				52D0CF1C25188BA30074D3C4 /* EncryptedBalance.swift in Sources */,
@@ -5858,7 +5859,6 @@
 				7F21398524236C0A00D2A5C4 /* CreateCredentialRequest.swift in Sources */,
 				7F5F77822487D3BD0016F8D1 /* IdentityProviderWebViewViewController.swift in Sources */,
 				5251EF8E27BA6803006991DD /* ShowShieldedDelegate.swift in Sources */,
-				901F7F1D27EA0F1B00C46741 /* PoolParametersResponse.swift in Sources */,
 				19C2EB170045945CE5D47CC8 /* IPInfoResponseElement.swift in Sources */,
 				52DCAA0127CD619A00CDF85E /* BurgerMenuAccountDetailsPresenter.swift in Sources */,
 				528EB74B255C30AD00010554 /* InitialAccountInfoViewController.swift in Sources */,

--- a/ConcordiumWallet/Model/AutoGenerated/ChainParametersResponse.swift
+++ b/ConcordiumWallet/Model/AutoGenerated/ChainParametersResponse.swift
@@ -1,25 +1,25 @@
 // This file was generated from JSON Schema using quicktype, do not modify it directly.
 // To parse the JSON, add this file to your project and do:
 //
-//   let poolParametersResponse = try PoolParametersResponse(json)
+//   let chainParametersResponse = try ChainParametersResponse(json)
 
 import Foundation
 
-// MARK: - PoolParametersResponse
-struct PoolParametersResponse: Codable {
+// MARK: - ChainParametersResponse
+struct ChainParametersResponse: Codable {
     let mintPerPayday: Double
     let rewardParameters: RewardParameters
     let poolOwnerCooldown: Int
     let capitalBound: Double
     let microGTUPerEuro: EuroPerEnergy
     let rewardPeriodLength: Int
-    let transactionCommissionLPool: Double
+    let passiveTransactionCommission: Double
     let leverageBound: EuroPerEnergy
     let foundationAccountIndex: Int
-    let finalizationCommissionLPool: Double
+    let passiveFinalizationCommission: Double
     let delegatorCooldown: Int
     let bakingCommissionRange: CommissionRange
-    let bakingCommissionLPool: Double
+    let passiveBakingCommission: Double
     let accountCreationLimit: Int
     let finalizationCommissionRange: CommissionRange
     let electionDifficulty: Double
@@ -34,13 +34,13 @@ struct PoolParametersResponse: Codable {
         case capitalBound = "capitalBound"
         case microGTUPerEuro = "microGTUPerEuro"
         case rewardPeriodLength = "rewardPeriodLength"
-        case transactionCommissionLPool = "transactionCommissionLPool"
+        case passiveTransactionCommission = "passiveTransactionCommission"
         case leverageBound = "leverageBound"
         case foundationAccountIndex = "foundationAccountIndex"
-        case finalizationCommissionLPool = "finalizationCommissionLPool"
+        case passiveFinalizationCommission = "passiveFinalizationCommission"
         case delegatorCooldown = "delegatorCooldown"
         case bakingCommissionRange = "bakingCommissionRange"
-        case bakingCommissionLPool = "bakingCommissionLPool"
+        case passiveBakingCommission = "passiveBakingCommission"
         case accountCreationLimit = "accountCreationLimit"
         case finalizationCommissionRange = "finalizationCommissionRange"
         case electionDifficulty = "electionDifficulty"
@@ -50,11 +50,11 @@ struct PoolParametersResponse: Codable {
     }
 }
 
-// MARK: PoolParametersResponse convenience initializers and mutators
+// MARK: ChainParametersResponse convenience initializers and mutators
 
-extension PoolParametersResponse {
+extension ChainParametersResponse {
     init(data: Data) throws {
-        self = try newJSONDecoder().decode(PoolParametersResponse.self, from: data)
+        self = try newJSONDecoder().decode(ChainParametersResponse.self, from: data)
     }
 
     init(_ json: String, using encoding: String.Encoding = .utf8) throws {
@@ -75,34 +75,34 @@ extension PoolParametersResponse {
         capitalBound: Double? = nil,
         microGTUPerEuro: EuroPerEnergy? = nil,
         rewardPeriodLength: Int? = nil,
-        transactionCommissionLPool: Double? = nil,
+        passiveTransactionCommission: Double? = nil,
         leverageBound: EuroPerEnergy? = nil,
         foundationAccountIndex: Int? = nil,
-        finalizationCommissionLPool: Double? = nil,
+        passiveFinalizationCommission: Double? = nil,
         delegatorCooldown: Int? = nil,
         bakingCommissionRange: CommissionRange? = nil,
-        bakingCommissionLPool: Double? = nil,
+        passiveBakingCommission: Double? = nil,
         accountCreationLimit: Int? = nil,
         finalizationCommissionRange: CommissionRange? = nil,
         electionDifficulty: Double? = nil,
         euroPerEnergy: EuroPerEnergy? = nil,
         transactionCommissionRange: CommissionRange? = nil,
         minimumEquityCapital: String? = nil
-    ) -> PoolParametersResponse {
-        return PoolParametersResponse(
+    ) -> ChainParametersResponse {
+        return ChainParametersResponse(
             mintPerPayday: mintPerPayday ?? self.mintPerPayday,
             rewardParameters: rewardParameters ?? self.rewardParameters,
             poolOwnerCooldown: poolOwnerCooldown ?? self.poolOwnerCooldown,
             capitalBound: capitalBound ?? self.capitalBound,
             microGTUPerEuro: microGTUPerEuro ?? self.microGTUPerEuro,
             rewardPeriodLength: rewardPeriodLength ?? self.rewardPeriodLength,
-            transactionCommissionLPool: transactionCommissionLPool ?? self.transactionCommissionLPool,
+            passiveTransactionCommission: passiveTransactionCommission ?? self.passiveTransactionCommission,
             leverageBound: leverageBound ?? self.leverageBound,
             foundationAccountIndex: foundationAccountIndex ?? self.foundationAccountIndex,
-            finalizationCommissionLPool: finalizationCommissionLPool ?? self.finalizationCommissionLPool,
+            passiveFinalizationCommission: passiveFinalizationCommission ?? self.passiveFinalizationCommission,
             delegatorCooldown: delegatorCooldown ?? self.delegatorCooldown,
             bakingCommissionRange: bakingCommissionRange ?? self.bakingCommissionRange,
-            bakingCommissionLPool: bakingCommissionLPool ?? self.bakingCommissionLPool,
+            passiveBakingCommission: passiveBakingCommission ?? self.passiveBakingCommission,
             accountCreationLimit: accountCreationLimit ?? self.accountCreationLimit,
             finalizationCommissionRange: finalizationCommissionRange ?? self.finalizationCommissionRange,
             electionDifficulty: electionDifficulty ?? self.electionDifficulty,

--- a/ConcordiumWallet/Model/TransferCostParameters.swift
+++ b/ConcordiumWallet/Model/TransferCostParameters.swift
@@ -13,7 +13,7 @@ enum TransferCostParameter {
     
     case amount // only for updateDelegation updateBakerStake or configureBaker
     case restake // only for updateDelegation, updateBakerStake or configureBaker
-    case lpool // only for registerDelegation or updateDelegation
+    case passive // only for registerDelegation or updateDelegation
     case target // only for updateDelegation
     
     case metadataSize(Int) // only for registerBaker, updateBakerPool or configureBaker
@@ -30,8 +30,8 @@ enum TransferCostParameter {
             return "amount"
         case .restake:
             return "restake"
-        case .lpool:
-            return "lPool"
+        case .passive:
+            return "passive"
         case .target:
             return "target"
         case .metadataSize:

--- a/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
+++ b/ConcordiumWallet/Resources/ConcordiumWallet/Base.lproj/Localizable.strings
@@ -244,9 +244,8 @@ process on-chain.";
 "accountDetails.noIdentities" = "This account has no revealed identity data.";
 "identityFailed.title" = "Identity issuance failed!";
 "accountDetails.bakingstakelabel" = "Stake with baker %@";
-"accountDetails.delegationstakeLabel" = "Delegation to %@";
-"accountDetails.lpoolvalue" = "L-Pool";
-"accountDetails.bakerpoolvalue" = "baker pool %d";
+"accountDetails.passivevalue" = "Passive delegation";
+"accountDetails.bakerpoolvalue" = "Delegation with baker pool %d";
 
 "sendFund.pageTitle.send" = "Send Funds";
 "sendFund.pageTitle.shieldAmount" = "Shield Amount";
@@ -539,13 +538,17 @@ concordium-backup.concordiumwallet securely.";
 "delegation.pool.title.create" = "Register delegation";
 "delegation.pool.title.update" = "Update delegation";
 "delegation.pool.current" = "Current target %@";
-"delegation.pool.message" = "You can delegate to a specific open pool of your choice, or you can delegate to the L-pool. ";
-"delegation.pool.bottommessage" = "If you don’t already know what target baker pool you want to delegate an amount to, you can read more about how to find one here:
+"delegation.pool.message" = "You can delegate to an open pool of your choice, or you can stake using passive delegation.";
+"delegation.pool.bottommessage.baker" = "If you don’t already know what target baker pool you want to delegate an amount to, you can read more about how to find one here:
 
+developer.concordium.software";
+"delegation.pool.bottommessage.passive" = "Passive delegation divides the staked tokens shared between all baker pools proportionally to their size, and has a higher commission rate than delegating to a single baker.
+
+For more info you can visit
 developer.concordium.software";
 
 "delegation.pool.baker" = "Baker";
-"delegation.pool.lpool" = "L-pool";
+"delegation.pool.passive" = "Passive";
 "delegation.pool.idplaceholder.create" = "Enter target baker pool ID";
 "delegation.pool.idplaceholder.update" = "Optional: Enter new target ID";
 "delegation.pool.invalidbakerid" = "Invalid target baker pool ID";
@@ -560,12 +563,9 @@ developer.concordium.software";
 "delegation.receipt.accounttodelegate" = "Account to delegate from";
 "delegation.receipt.accounttostop" = "Account to stop delegating";
 "delegation.receipt.delegationamount" = "Delegation amount";
-"delegation.receipt.tagetbakerpool" = "Current target";
+"delegation.receipt.tagetbakerpool" = "Target";
 
-
-
-"delegation.receipt.lpoolvalue" = "L-pool";
-"delegation.receipt.bakerpoolvalue" = "Baker id %d";
+"delegation.receipt.passivevalue" = "Passive delegation";
 "delegation.receipt.addedtodelegation" = "Added to delegation amount";
 "delegation.receipt.notaddedtodelegation" = "At disposal";
 
@@ -672,9 +672,9 @@ If your pool is already open, you can also close it for new delegators, or you c
 
 "onboardingcarousel.registerdelegation.title" = "Delegation";
 "onboardingcarousel.registerdelegation.page1.title" = "Delegation";
-"onboardingcarousel.registerdelegation.page2.title" = "Two types of pools";
+"onboardingcarousel.registerdelegation.page2.title" = "Delegation models";
 "onboardingcarousel.registerdelegation.page3.title" = "Baker pools";
-"onboardingcarousel.registerdelegation.page4.title" = "The L-pool";
+"onboardingcarousel.registerdelegation.page4.title" = "Passive delegation";
 "onboardingcarousel.registerdelegation.page5.title" = "Pay days";
 "onboardingcarousel.registerdelegation.page6.title" = "Lock-in and cool-downs";
 "onboardingcarousel.registerdelegation.page7.title" = "The status page";

--- a/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_2.html
+++ b/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_2.html
@@ -11,12 +11,12 @@
     <p>
 		There are two staking models that a delegator can choose:
         <ul>
-            <li>Delegating to a chosen baker’s pool.</li>
+            <li>Delegating to a chosen baker's pool.</li>
             <li>Passive delegation in which the tokens are shared amongst all pools.</li>
         </ul>
     </p>
     <p>
-    	A baker pool is managed by an individual baker running a node so the rewards depend on that baker’s performance.
+    	A baker pool is managed by an individual baker running a node so the rewards depend on that baker's performance.
     </p>
     <p>
     	Since the passive delegation scheme shares the tokens amongst all bakers, it mitigates the risk of a single baker performing badly, but the commissions are set higher.

--- a/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_2.html
+++ b/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_2.html
@@ -9,17 +9,20 @@
 
 <body>
     <p>
-        There are two types of pools for delegation:
+		There are two staking models that a delegator can choose:
         <ul>
-            <li>Baker pools</li>
-            <li>The lock-up pool, also known as the L-pool</li>
+            <li>Delegating to a chosen baker’s pool.</li>
+            <li>Passive delegation in which the tokens are shared amongst all pools.</li>
         </ul>
     </p>
     <p>
-        A baker pool is managed by an individual baker running a node, while the L-pool is a common pool that lives on the entire blockchain.
+    	A baker pool is managed by an individual baker running a node so the rewards depend on that baker’s performance.
     </p>
     <p>
-        Both earn rewards, though at different rates.
+    	Since the passive delegation scheme shares the tokens amongst all bakers, it mitigates the risk of a single baker performing badly, but the commissions are set higher.
+    </p>
+    <p>
+    	For more info visit <a href="https://developer.concordium.software">developer.concordium.software</a>
     </p>
 </body>
 

--- a/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_3.html
+++ b/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_3.html
@@ -19,7 +19,7 @@
     </p>
 
     <p>
-        Delegating to a baker pool is usually more profitable than to delegate to the L-pool, but there is also a risk of losing out on rewards if the baker is not running properly. It is therefor a good idea to keep an eye on the baker's performance.
+    	Delegating to a baker pool is usually more profitable than passive delegation, but there is also a risk of losing out on rewards if the baker is not running properly. It is therefor a good idea to keep an eye on the baker’s performance.
     </p>
 
     <p>

--- a/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_4.html
+++ b/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_4.html
@@ -9,15 +9,15 @@
 
 <body>
     <p>
-    For CCD holders who do not want to regularly check the performance of their pool, but just want a stable way of earning interest, the L-pool (Lock-up pool) offers a low-risk, low-reward alternative.
+    For CCD holders who do not want to regularly check the performance of a chosen pool, but just want a stable way of earning interest, passive delegation offers a low-risk, low-reward alternative.
     </p>
 
     <p>
-    This pool is not associated with a specific baker, so there is no risk of poor baker health.
+    This staking strategy is not associated with a specific baker, since the tokens are shared amongst all pools, so there is no risk of poor baker health.
     </p>
 
     <p>
-    The trade off when choosing the stable L-pool is that the return of your stake will be less than what you might see with a baker pool.
+    The trade off when choosing passive delegation is that the return of your stake will be less than what you might see with a baker pool, both because the commission is higher and because it will have average performance.
     </p>
 </body>
 

--- a/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_5.html
+++ b/ConcordiumWallet/Resources/RegisterDelegationOnboarding/delegation_intro_flow_en_5.html
@@ -9,7 +9,7 @@
 
 <body>
     <p>
-    Whether you choose an individual baking pool or the L-pool, rewards are paid out at what is called the pay day. Rewards are distributed to everyone in the pool proportional to their stake, and a commission is paid to the baker by all delegators.
+    Whether you choose an individual baking pool or passive delegation, rewards are paid out at what is called the pay day. Rewards are distributed to everyone in the pool proportional to their stake, and a commission is paid to the baker by all delegators.
     </p>
     <p>
     If you make updates to your delegation at a later point, most of these will also take effect from the next pay day.

--- a/ConcordiumWallet/Service/Network/ApiConstants.swift
+++ b/ConcordiumWallet/Service/Network/ApiConstants.swift
@@ -43,7 +43,7 @@ struct ApiConstants {
     static let gtuDrop = proxyUrl.appendingPathComponent("/v0/testnetGTUDrop")
     
     static let bakerPool = proxyUrl.appendingPathComponent("/v0/bakerPool")
-    static let poolParameters = proxyUrl.appendingPathComponent("/v0/chainParameters")
+    static let chainParameters = proxyUrl.appendingPathComponent("/v0/chainParameters")
     
     /// Generate a callback URI associated with an identifier
     static func callbackUri(with identityCreationID: String) -> String {

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewModel.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewModel.swift
@@ -59,9 +59,10 @@ class AccountDetailsViewModel {
                 self.stakedValue = GTU(intValue: baker.stakedAmount ).displayValueWithGStroke()
                 
             } else if let delegation = account.delegation {
-                let pool = BakerPool.from(delegationType: delegation.delegationTargetType, bakerId: delegation.delegationTargetBakerID)
+                let pool = BakerTarget.from(delegationType: delegation.delegationTargetType, bakerId: delegation.delegationTargetBakerID)
+                
                 self.hasStaked = true
-                self.stakedLabel = String(format: "accountDetails.delegationstakeLabel".localized, pool.getDisplayValueForAccountDetails())
+                self.stakedLabel = pool.getDisplayValueForAccountDetails()
                 self.stakedValue = GTU(intValue: Int(delegation.stakedAmount) ).displayValueWithGStroke()
             } else {
                 self.hasStaked = false
@@ -122,11 +123,11 @@ class AccountDetailsViewModel {
     }
 }
 
-extension BakerPool {
+extension BakerTarget {
     fileprivate func getDisplayValueForAccountDetails() -> String {
         switch self {
-        case .lpool:
-            return "accountDetails.lpoolvalue".localized
+        case .passive:
+            return "accountDetails.passivevalue".localized
         case .bakerPool(let bakerId):
             return String(format: "accountDetails.bakerpoolvalue".localized, bakerId)
         }

--- a/ConcordiumWallet/Views/AccountsView/StakeService.swift
+++ b/ConcordiumWallet/Views/AccountsView/StakeService.swift
@@ -11,7 +11,7 @@ import Combine
 
 protocol StakeServiceProtocol {
     func getBakerPool(bakerId: Int) -> AnyPublisher<BakerPoolResponse, Error>
-    func getPoolParameters() -> AnyPublisher<PoolParametersResponse, Error> 
+    func getChainParameters() -> AnyPublisher<ChainParametersResponse, Error>
 }
 
 class StakeService: StakeServiceProtocol {
@@ -21,8 +21,8 @@ class StakeService: StakeServiceProtocol {
 
     }
     
-    func getPoolParameters() -> AnyPublisher<PoolParametersResponse, Error> {
-        let request = ResourceRequest(url: ApiConstants.poolParameters)
+    func getChainParameters() -> AnyPublisher<ChainParametersResponse, Error> {
+        let request = ResourceRequest(url: ApiConstants.chainParameters)
         return networkManager.load(request)
     }
     

--- a/ConcordiumWallet/Views/Stake/Common/StakeDataHandler.swift
+++ b/ConcordiumWallet/Views/Stake/Common/StakeDataHandler.swift
@@ -178,8 +178,8 @@ class DelegationStopAccountData: AccountData {
 }
 
 class PoolDelegationData: StakeData {
-    var pool: BakerPool
-    init(pool: BakerPool) {
+    var pool: BakerTarget
+    init(pool: BakerTarget) {
         self.pool = pool
         super.init(field: .pool)
     }
@@ -345,8 +345,8 @@ class StakeDataHandler {
                 return [.restake]
             case let poolData as PoolDelegationData:
                 switch poolData.pool {
-                case .lpool:
-                    return [.lpool, .target]
+                case .passive:
+                    return [.passive, .target]
                 case .bakerPool:
                     return [.target]
                 }
@@ -368,8 +368,8 @@ class StakeDataHandler {
                 transfer.restakeEarnings = data.restake
             case let poolData as PoolDelegationData:
                 switch poolData.pool {
-                case .lpool:
-                    transfer.delegationType = "L-Pool"
+                case .passive:
+                    transfer.delegationType = "Passive"
                 case .bakerPool(let bakerId):
                     transfer.delegationType = "Baker"
                     transfer.delegationTargetBaker = bakerId

--- a/ConcordiumWallet/Views/Stake/Delegation/AmountInput/DelegationInputPresenter.swift
+++ b/ConcordiumWallet/Views/Stake/Delegation/AmountInput/DelegationInputPresenter.swift
@@ -119,7 +119,7 @@ class DelegationAmountInputPresenter: StakeAmountInputPresenterProtocol {
         let showsPoolLimits: Bool!
         // If we are updating delegation and we dont't change the pool,
         // we need to check the existing value of the pool
-        let pool: BakerPool
+        let pool: BakerTarget
         if let newPool = newPool?.pool {
             pool = newPool
             // if pool is changed, then the previously staked is incorrect
@@ -128,11 +128,11 @@ class DelegationAmountInputPresenter: StakeAmountInputPresenterProtocol {
             pool = existingPool
             previouslyStakedInSelectedPool = self.account.delegation?.stakedAmount ?? 0
         } else {
-            pool = .lpool
+            pool = .passive
             previouslyStakedInSelectedPool = self.account.delegation?.stakedAmount ?? 0
         }
         
-        if case .lpool = pool {
+        if case .passive = pool {
             showsPoolLimits = false
         } else {
             showsPoolLimits = true

--- a/ConcordiumWallet/Views/Stake/Delegation/DelegationDataHandler.swift
+++ b/ConcordiumWallet/Views/Stake/Delegation/DelegationDataHandler.swift
@@ -20,7 +20,7 @@ class DelegationDataHandler: StakeDataHandler {
                 currentData?.update(with: DelegationAccountData(accountAddress: account.address))
                 currentData?.update(with: AmountData(amount: GTU(intValue: delegation.stakedAmount)))
                 currentData?.update(with: RestakeDelegationData(restake: delegation.restakeEarnings))
-                let bakerPool = BakerPool.from(delegationType: delegation.delegationTargetType, bakerId: delegation.delegationTargetBakerID)
+                let bakerPool = BakerTarget.from(delegationType: delegation.delegationTargetType, bakerId: delegation.delegationTargetBakerID)
                 currentData?.update(with: PoolDelegationData(pool: bakerPool))
                 self.add(entry: DelegationAccountData(accountAddress: account.address))
             }

--- a/ConcordiumWallet/Views/Stake/Delegation/PoolSelection/DelegationPoolSelectionViewController.swift
+++ b/ConcordiumWallet/Views/Stake/Delegation/PoolSelection/DelegationPoolSelectionViewController.swift
@@ -67,7 +67,7 @@ class DelegationPoolSelectionViewController: KeyboardDismissableBaseViewControll
         poolSelectionSegmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.black], for: .normal)
         poolSelectionSegmentedControl.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.whiteText], for: .selected)
         poolSelectionSegmentedControl.setTitle("delegation.pool.baker".localized, forSegmentAt: 0)
-        poolSelectionSegmentedControl.setTitle("delegation.pool.lpool".localized, forSegmentAt: 1)
+        poolSelectionSegmentedControl.setTitle("delegation.pool.passive".localized, forSegmentAt: 1)
         
         presenter.view = self
         presenter.viewDidLoad()

--- a/ConcordiumWallet/Views/Stake/Delegation/Status/DelegationStatusPresenter.swift
+++ b/ConcordiumWallet/Views/Stake/Delegation/Status/DelegationStatusPresenter.swift
@@ -58,13 +58,13 @@ class DelegationStatusPresenter: StakeStatusPresenterProtocol {
     }
     
     func pressedButton() {
-        stakeService.getPoolParameters()
+        stakeService.getChainParameters()
             .showLoadingIndicator(in: self.view)
             .sink { [weak self] error in
                 self?.view?.showErrorAlert(ErrorMapper.toViewError(error: error))
-            } receiveValue: { [weak self] poolParameterResponse in
-                let params = ChainParametersEntity(delegatorCooldown: poolParameterResponse.delegatorCooldown,
-                                                   poolOwnerCooldown: poolParameterResponse.poolOwnerCooldown)
+            } receiveValue: { [weak self] chainParametersResponse in
+                let params = ChainParametersEntity(delegatorCooldown: chainParametersResponse.delegatorCooldown,
+                                                   poolOwnerCooldown: chainParametersResponse.poolOwnerCooldown)
                 do {
                     _ = try self?.storageManager.updateChainParms(params)
                     self?.delegate?.pressedRegisterOrUpdate()
@@ -75,14 +75,14 @@ class DelegationStatusPresenter: StakeStatusPresenterProtocol {
     }
 
     func pressedStopButton() {
-        stakeService.getPoolParameters()
+        stakeService.getChainParameters()
             .zip(transactionService.getTransferCost(transferType: .removeDelegation, costParameters: []))
             .showLoadingIndicator(in: view)
             .sink { [weak self] error in
                 self?.view?.showErrorAlert(ErrorMapper.toViewError(error: error))
-            } receiveValue: {[weak self] (poolParameterResponse, transferCost) in
-                let params = ChainParametersEntity(delegatorCooldown: poolParameterResponse.delegatorCooldown,
-                                                   poolOwnerCooldown: poolParameterResponse.poolOwnerCooldown)
+            } receiveValue: {[weak self] (chainParametersResponse, transferCost) in
+                let params = ChainParametersEntity(delegatorCooldown: chainParametersResponse.delegatorCooldown,
+                                                   poolOwnerCooldown: chainParametersResponse.poolOwnerCooldown)
                 do {
                     _ = try self?.storageManager.updateChainParms(params)
                     let cost = GTU(intValue: Int(transferCost.cost) ?? 0)

--- a/ConcordiumWallet/mock/4.1.2.RX_backend_accBalance.json
+++ b/ConcordiumWallet/mock/4.1.2.RX_backend_accBalance.json
@@ -53,7 +53,7 @@
             "stakedAmount": "50000000",
             "restakeEarnings": true,
             "delegationTarget": {
-                    "delegateType": "L-Pool",
+                    "delegateType": "Passive",
                     "bakerId": null
             },
             "pendingChange":{

--- a/ConcordiumWallet/mock/5.2.2.RX_backend_chain_parameters.json
+++ b/ConcordiumWallet/mock/5.2.2.RX_backend_chain_parameters.json
@@ -1,9 +1,9 @@
 {
-    "mintPerPayday": 7.48246766e-6,
+    "mintPerPayday": 1.088e-5,
     "rewardParameters": {
         "mintDistribution": {
-            "bakingReward": 0.45,
-            "finalizationReward": 0.35
+            "bakingReward": 0.6,
+            "finalizationReward": 0.3
         },
         "transactionFeeDistribution": {
             "gasAccount": 0.45,
@@ -16,30 +16,30 @@
             "finalizationProof": 5.0e-3
         }
     },
-    "poolOwnerCooldown": 10801,
-    "capitalBound": 0.3,
+    "poolOwnerCooldown": 10800,
+    "capitalBound": 0.25,
     "microGTUPerEuro": {
-        "denominator": 58433945727,
-        "numerator": 1468275604309659776
+        "denominator": 520665778663,
+        "numerator": 15680480332915073024
     },
-    "rewardPeriodLength": 3,
-    "transactionCommissionLPool": 0.1,
+    "rewardPeriodLength": 4,
+    "passiveTransactionCommission": 0.1,
     "leverageBound": {
         "denominator": 1,
-        "numerator": 2
+        "numerator": 3
     },
     "foundationAccountIndex": 5,
-    "finalizationCommissionLPool": 1.0,
-    "delegatorCooldown": 7201,
+    "passiveFinalizationCommission": 1.0,
+    "delegatorCooldown": 7200,
     "bakingCommissionRange": {
         "max": 5.0e-2,
         "min": 5.0e-2
     },
-    "bakingCommissionLPool": 0.1,
+    "passiveBakingCommission": 0.1,
     "accountCreationLimit": 10,
     "finalizationCommissionRange": {
-        "max": 1.0,
-        "min": 1.0
+        "max": 5.0e-2,
+        "min": 5.0e-2
     },
     "electionDifficulty": 2.5e-2,
     "euroPerEnergy": {
@@ -50,5 +50,5 @@
         "max": 5.0e-2,
         "min": 5.0e-2
     },
-    "minimumEquityCapital": "1000000000"
+    "minimumEquityCapital": "14000000000"
 }

--- a/Scripts/createModel.sh
+++ b/Scripts/createModel.sh
@@ -26,7 +26,7 @@ ACCOUNT_PUBLIC_KEY="../ConcordiumWallet/mock/4.3.2.RX_backend_accEncryptionKey.j
 SERVER_ERROR="../ConcordiumWallet/mock/backend_server_error.json"
 DECRYPT_AMOUNT_JSON="../ConcordiumWallet/mock/4.4.1.TX_lib_decrypt_encrypted_amount.json"
 BAKER_POOL_JSON="../ConcordiumWallet/mock/5.1.2.RX_backend_baker_pool.json"
-POOL_PARAMETERS_JSON="../ConcordiumWallet/mock/5.2.2.RX_backend_pool_parameters.json"
+CHAIN_PARAMETERS_JSON="../ConcordiumWallet/mock/5.2.2.RX_backend_chain_parameters.json"
 
 
 GENERATE_ACCOUNTS_JSON="../ConcordiumWallet/mock/4.5.1.TX_lib_generate_accounts.json"
@@ -133,7 +133,7 @@ replaceType "PendingChange.change: String?" "change: String"
 cat $ACCOUNT_TRANSACTIONS | quicktype --multi-file-output --all-properties-optional --density normal -o $DEST/RemoteTransactions.swift
 cat $ACCOUNT_PUBLIC_KEY | quicktype --multi-file-output --all-properties-optional --density normal -o $DEST/PublicEncriptionKey.swift
 cat $BAKER_POOL_JSON | quicktype --multi-file-output --density normal -o $DEST/baker_pool_response.swift
-cat $POOL_PARAMETERS_JSON | quicktype --multi-file-output --density normal -o $DEST/pool_parameters_response.swift
+cat $CHAIN_PARAMETERS_JSON | quicktype --multi-file-output --density normal -o $DEST/chain_parameters_response.swift
 replaceType "BakerStakePendingChange.bakerEquityCapital: String" "bakerEquityCapital: String?"
 replaceType "EuroPerEnergy.Int" "UInt64"
 replaceType "BakerStakePendingChange.effectiveTime: String" "effectiveTime: String?"


### PR DESCRIPTION
## Purpose

The L-Pool is being renamed to passive delegation. This pull request addresses this.

## Changes

- UI has been updated according to changes described
- References has been renamed to reflect the new name
- Calls to mobile wallet and backend has been updated to reflect the new names

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
