### PR TITLE
Fall back to raw "document type" when no localized string is matched

### DIFF
--- a/ConcordiumWallet/Presentation/AttributesFormatter.swift
+++ b/ConcordiumWallet/Presentation/AttributesFormatter.swift
@@ -123,23 +123,20 @@ private class InternalFormatter {
     }
     
     func format(documentType: String) -> String {
-        guard let documentTypeEnum = DocumentType(rawValue: documentType) else {
-            return ""
-        }
-        var formattedDocumentType = ""
-        switch documentTypeEnum {
+        switch DocumentType(rawValue: documentType) {
+            case nil:
+                return documentType; // unknown type; no localized string available
             case .na:
-                formattedDocumentType = "Not applicable".localized
+                return  "Not applicable".localized
             case .drivingLicense:
-                formattedDocumentType = "Driving License".localized
+                return "Driving License".localized
             case .ImmigrationCard:
-                formattedDocumentType = "Immigration Card".localized
+                return "Immigration Card".localized
             case .nationalIDCard:
-                formattedDocumentType = "National ID".localized
+                return "National ID".localized
             case .passport:
-                formattedDocumentType = "Passport".localized
+                return "Passport".localized
         }
-        return formattedDocumentType
     }
     
     func countryName(for countryCode: String) -> String {

--- a/ConcordiumWalletTests/Presentation/AttributesFormatterTests.swift
+++ b/ConcordiumWalletTests/Presentation/AttributesFormatterTests.swift
@@ -76,7 +76,8 @@ class AttributesFormatterTests: XCTestCase {
                       ("1", "Passport".localized),
                       ("2", "National ID".localized),
                       ("3", "Driving License".localized),
-                      ("4", "Immigration Card".localized)
+                      ("4", "Immigration Card".localized),
+                      ("x", "x")
                      ]
         
         for value in values {


### PR DESCRIPTION
## Purpose

Currently, the "document type" attribute is empty when it doesn't match any of the currently known values.

## Changes

Fall back to the raw "document type" value when no localized string is matched.

Resolves https://concordium.atlassian.net/browse/CBW-907.

I don't think the base branch of this PR is the correct one to merge into, but I don't know which one is..?

I also cannot run the tests due to compiler errors like `/Users/mo/work/concordium-reference-wallet-ios/ConcordiumWallet/Model/Environment.swift:28:16 Cannot convert value of type 'String' to specified type 'Environment'` (fixing this results in other errors elsewhere).