### PR TITLE
Fix app crashing on camera user verification via Notabene

### DIFF
--- a/ConcordiumWallet/Resources/ConcordiumWallet-mock-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWallet-mock-Info.plist
@@ -90,5 +90,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
 </dict>
 </plist>

--- a/ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist
@@ -78,5 +78,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
 </dict>
 </plist>

--- a/ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist
@@ -76,5 +76,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
 </dict>
 </plist>

--- a/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
@@ -74,6 +74,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 </dict>


### PR DESCRIPTION
## Purpose
The app crashes when user tries to use Notabene to add identity. 

## Changes
I added `NSMicrophoneUsageDescription ` property to *.plist files in order to request user for microphone usage permission. 