### PR TITLE
Move showWalletConnectScanner from AppCoordinator

### DIFF
--- a/ConcordiumWallet/AppCoordinator.swift
+++ b/ConcordiumWallet/AppCoordinator.swift
@@ -254,20 +254,6 @@ class AppCoordinator: NSObject, Coordinator, ShowAlert, RequestPasswordDelegate 
 }
 
 extension AppCoordinator: AccountsPresenterDelegate {
-    func showWalletConnectScanner() {
-        let vc = ScanQRViewControllerFactory.create(
-            with: ScanQRPresenter(
-                strategy: WalletConnectStrategy(),
-                didScanQrCode: { [weak self] address in
-                    // Successfully scanner WalletConnect QR.
-                    // TODO: Handle Wallet Connect logic here
-                    self?.navigationController.popViewController(animated: true)
-                }
-            )
-        )
-        navigationController.pushViewController(vc, animated: true)
-    }
-
     func userPerformed(action: AccountCardAction, on account: AccountDataType) {
         accountsCoordinator?.userPerformed(action: action, on: account)
     }

--- a/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsCoordinator.swift
@@ -42,12 +42,13 @@ class AccountsCoordinator: Coordinator {
     }
 
     func start() {
-        let AccountsPresenter = AccountsPresenter(
+        let accountsPresenter = AccountsPresenter(
             dependencyProvider: dependencyProvider,
-            delegate: self.accountsPresenterDelegate!,
-            appSettingsDelegate: appSettingsDelegate
+            delegate: accountsPresenterDelegate!,
+            appSettingsDelegate: appSettingsDelegate,
+            walletConnectDelegate: self
         )
-        let accountsViewController = AccountsFactory.create(with: AccountsPresenter)
+        let accountsViewController = AccountsFactory.create(with: accountsPresenter)
         navigationController.viewControllers = [accountsViewController]
     }
 
@@ -238,5 +239,25 @@ extension AccountsCoordinator: SeedIdentitiesCoordinatorDelegate {
         childCoordinators.removeAll(where: { $0 is SeedIdentitiesCoordinator })
         
         NotificationCenter.default.post(name: Notification.Name("seedAccountCoordinatorWasFinishedNotification"), object: nil)
+    }
+}
+
+protocol WalletConnectDelegate: AnyObject {
+    func showWalletConnectScanner()
+}
+
+extension AccountsCoordinator: WalletConnectDelegate {
+    func showWalletConnectScanner() {
+        let vc = ScanQRViewControllerFactory.create(
+            with: ScanQRPresenter(
+                strategy: WalletConnectStrategy(),
+                didScanQrCode: { [weak self] address in
+                    // Successfully scanner WalletConnect QR.
+                    // TODO: Handle Wallet Connect logic here
+                    self?.navigationController.popViewController(animated: true)
+                }
+            )
+        )
+        navigationController.pushViewController(vc, animated: true)
     }
 }

--- a/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountsPresenter.swift
@@ -124,11 +124,6 @@ protocol AccountsPresenterDelegate: AnyObject {
     func didSelectMakeBackup()
     func didSelectPendingIdentity(identity: IdentityDataType)
     func showSettings()
-    func showWalletConnectScanner()
-}
-
-extension AccountsPresenterDelegate {
-    func showWalletConnectScanner() {}
 }
 
 // MARK: View
@@ -166,6 +161,7 @@ class AccountsPresenter: AccountsPresenterProtocol {
     var alertDisplayer = AlertDisplayer()
     private var dependencyProvider: AccountsFlowCoordinatorDependencyProvider
     private weak var appSettingsDelegate: AppSettingsDelegate?
+    private weak var walletConnectDelegate: WalletConnectDelegate?
 
     var pendingIdentity: IdentityDataType?
     
@@ -196,7 +192,8 @@ class AccountsPresenter: AccountsPresenterProtocol {
     init(
         dependencyProvider: AccountsFlowCoordinatorDependencyProvider,
         delegate: AccountsPresenterDelegate,
-        appSettingsDelegate: AppSettingsDelegate?
+        appSettingsDelegate: AppSettingsDelegate?,
+        walletConnectDelegate: WalletConnectDelegate?
     ) {
         self.dependencyProvider = dependencyProvider
         self.delegate = delegate
@@ -207,6 +204,7 @@ class AccountsPresenter: AccountsPresenterProtocol {
             self?.viewModel.warning = warningVM
         }.store(in: &cancellables)
         self.alertDisplayer.delegate = self
+        self.walletConnectDelegate = walletConnectDelegate
     }
     
     func viewDidLoad() {
@@ -228,7 +226,7 @@ class AccountsPresenter: AccountsPresenterProtocol {
     }
     
     func showWalletConnectScanner() {
-        delegate?.showWalletConnectScanner()
+        walletConnectDelegate?.showWalletConnectScanner()
     }
     
     func refresh(pendingIdentity: IdentityDataType? = nil) {

--- a/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
+++ b/ConcordiumWallet/Views/MoreSection/MoreCoordinator.swift
@@ -310,8 +310,6 @@ extension MoreCoordinator: AppSettingsDelegate {
 }
 
 extension MoreCoordinator: AccountsPresenterDelegate {
-    func showWalletConnectScanner() {
-    }
 
     func createNewIdentity() {
         accountsCoordinator?.showCreateNewIdentity()


### PR DESCRIPTION
Moved `showWalletConnectScanner` from `AppCoordinator` to `AccountsCoordinator` (and from protocol `AccountsPresenterDelegate` to new one `WalletConnectDelegate`). `AccountsPresenter` gets `AppCoordinator` (as a `WalletConnectDelegate`) in a new init parameter.