### PR TITLE
WalletConnect: Expect transaction type to be provided as lower-case camelCase

### DIFF
--- a/ConcordiumWallet/Model/TransferType.swift
+++ b/ConcordiumWallet/Model/TransferType.swift
@@ -25,7 +25,7 @@ enum TransferType: String, Codable {
     case removeBaker
     case configureBaker
 
-    case contractUpdate = "Update"
+    case contractUpdate = "update"
     
     var isDelegationTransfer: Bool {
         switch self {


### PR DESCRIPTION
The value "Update" currently provided by the dapp-libraries remains supported for backwards compatibility.