### PR TITLE
WalletConnect: Use correct ID for network

### DIFF
--- a/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
+++ b/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
@@ -82,27 +82,22 @@ private extension WalletConnectCoordinator {
                 guard let self else { return }
                 print("DEBUG: WalletConnect: \(self) Session \(proposal) proposed")
 
-                // TODO: Auto-reject proposal if namespaces doesn't exactly match expected chain/method/event.
-                //      And show user appropriate error...
-                
-                let proposalData = proposal.proposalData
-                
                 // Check chain, methods and events. Reject if they don't match (fixed) expectations.
                 // We only check required namespaces, not the optional ones.
                 guard proposal.requiredNamespaces.count == 1, let ccdNamespace = proposal.requiredNamespaces[expectedNamespaceKey] else {
-                    self.reject(proposal: proposal, reason: .userRejected, msg: "Unexpected namespaces: \(proposal.requiredNamespaces.keys)", shouldPresent: true)
+                    self.reject(proposal: proposal, reason: .userRejected, msg: "Unexpected namespaces: \(proposal.requiredNamespaces.keys)")
                     return
                 }
                 if let chains = ccdNamespace.chains, chains != supportedChains {
-                    self.reject(proposal: proposal, reason: .userRejectedChains, msg: "Expected chain \"\(supportedChains)\" bot got \(chains)", shouldPresent: true)
+                    self.reject(proposal: proposal, reason: .userRejectedChains, msg: "Expected chain \"\(supportedChains)\" bot got \(chains)")
                     return
                 }
                 if !ccdNamespace.events.isSubset(of: supportedEvents) {
-                    self.reject(proposal: proposal, reason: .userRejectedEvents, msg: "Expected subset of events \(supportedEvents) but got \(ccdNamespace.events)", shouldPresent: true)
+                    self.reject(proposal: proposal, reason: .userRejectedEvents, msg: "Expected subset of events \(supportedEvents) but got \(ccdNamespace.events)")
                     return
                 }
                 if !ccdNamespace.methods.isSubset(of: supportedMethods) {
-                    self.reject(proposal: proposal, reason: .userRejectedMethods, msg: "Expected subset of methods \(supportedMethods) but got \(ccdNamespace.methods)", shouldPresent: true)
+                    self.reject(proposal: proposal, reason: .userRejectedMethods, msg: "Expected subset of methods \(supportedMethods) but got \(ccdNamespace.methods)")
                     return
                 }
 
@@ -115,7 +110,7 @@ private extension WalletConnectCoordinator {
                                     title: "walletconnect.connect.approve.title".localized,
                                     contentView: WalletConnectProposalApprovalView(
                                         accountName: account.displayName,
-                                        proposal: proposalData
+                                        proposal: proposal.proposalData
                                     ),
                                     viewModel: .init(
                                         didAccept: {
@@ -152,10 +147,10 @@ private extension WalletConnectCoordinator {
                                         }
                                     )
                                 )
-                        ),
-                        animated: true
-                    )
-                }
+                            ),
+                            animated: true
+                        )
+                    }
                 )
                 
                 self.navigationController.pushViewController(
@@ -188,7 +183,6 @@ private extension WalletConnectCoordinator {
                 
                 guard session.namespaces.count == 1, let ccdNamespace = session.namespaces["ccd"] else {
                     self?.parentCoordinator?.dismissWalletConnectCoordinator()
-
                     self?.disconnectAndPresentError(.sessionError(.unexpectedNamespaces(namespaces: Array(session.namespaces.keys))))
                     return
                 }
@@ -562,7 +556,7 @@ extension WalletConnectCoordinator: WalletConnectDelegate {
         }
     }
     
-    func reject(proposal: Session.Proposal, reason: RejectionReason, msg: String, shouldPresent: Bool) {
+    func reject(proposal: Session.Proposal, reason: RejectionReason, msg: String) {
         Task { [weak self] in
             do {
                 try await Sign.instance.reject(
@@ -576,9 +570,10 @@ extension WalletConnectCoordinator: WalletConnectDelegate {
                 )
             }
         }
-        if shouldPresent {
-            presentError(with: "errorAlert.title".localized, message: msg)
-        }
+        
+        navigationController.popToRootViewController(animated: true)
+        parentCoordinator?.dismissWalletConnectCoordinator() // disconnects any sessions
+        presentError(with: "errorAlert.title".localized, message: msg)
     }
     
     func disconnectAndPresentError(_ err: WalletConnectError) {

--- a/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
+++ b/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
@@ -54,8 +54,17 @@ class WalletConnectCoordinator: Coordinator {
 
 // MARK: - WalletConnect
 
+let expectedNetwork = { network in
+    switch network {
+    case .main:
+        return "mainnet"
+    case .test:
+        return "testnet"
+    }
+}(Net.current)
+
 let expectedNamespaceKey = "ccd"
-let expectedChain = "\(expectedNamespaceKey):testnet"
+let expectedChain = "\(expectedNamespaceKey):\(expectedNetwork)"
 let supportedChains = Set([Blockchain(expectedChain)!])
 let supportedEvents = Set(["accounts_changed", "chain_changed"])
 let supportedMethods = Set(["sign_and_send_transaction", "sign_message"])


### PR DESCRIPTION
On proposal, expect `chains` value `ccd:testnet` or `ccd:mainnet` depending on the network the app is built for.

This change also ensures that the QR code scanner is dismissed on proposal error.

Alternative to https://github.com/Concordium/concordium-reference-wallet-ios/pull/337.