### PR TITLE
Remove election difficulty from expected parameters.

### DIFF
--- a/ConcordiumWallet/Model/AutoGenerated/ChainParametersResponse.swift
+++ b/ConcordiumWallet/Model/AutoGenerated/ChainParametersResponse.swift
@@ -22,7 +22,6 @@ struct ChainParametersResponse: Codable {
     let passiveBakingCommission: Double
     let accountCreationLimit: Int
     let finalizationCommissionRange: CommissionRange
-    let electionDifficulty: Double
     let euroPerEnergy: EuroPerEnergy
     let transactionCommissionRange: CommissionRange
     let minimumEquityCapital: String
@@ -43,7 +42,6 @@ struct ChainParametersResponse: Codable {
         case passiveBakingCommission = "passiveBakingCommission"
         case accountCreationLimit = "accountCreationLimit"
         case finalizationCommissionRange = "finalizationCommissionRange"
-        case electionDifficulty = "electionDifficulty"
         case euroPerEnergy = "euroPerEnergy"
         case transactionCommissionRange = "transactionCommissionRange"
         case minimumEquityCapital = "minimumEquityCapital"
@@ -84,7 +82,6 @@ extension ChainParametersResponse {
         passiveBakingCommission: Double? = nil,
         accountCreationLimit: Int? = nil,
         finalizationCommissionRange: CommissionRange? = nil,
-        electionDifficulty: Double? = nil,
         euroPerEnergy: EuroPerEnergy? = nil,
         transactionCommissionRange: CommissionRange? = nil,
         minimumEquityCapital: String? = nil
@@ -105,7 +102,6 @@ extension ChainParametersResponse {
             passiveBakingCommission: passiveBakingCommission ?? self.passiveBakingCommission,
             accountCreationLimit: accountCreationLimit ?? self.accountCreationLimit,
             finalizationCommissionRange: finalizationCommissionRange ?? self.finalizationCommissionRange,
-            electionDifficulty: electionDifficulty ?? self.electionDifficulty,
             euroPerEnergy: euroPerEnergy ?? self.euroPerEnergy,
             transactionCommissionRange: transactionCommissionRange ?? self.transactionCommissionRange,
             minimumEquityCapital: minimumEquityCapital ?? self.minimumEquityCapital

--- a/ConcordiumWallet/mock/5.2.2.RX_backend_chain_parameters.json
+++ b/ConcordiumWallet/mock/5.2.2.RX_backend_chain_parameters.json
@@ -41,7 +41,6 @@
         "max": 5.0e-2,
         "min": 5.0e-2
     },
-    "electionDifficulty": 2.5e-2,
     "euroPerEnergy": {
         "denominator": 1000000,
         "numerator": 1


### PR DESCRIPTION
## Purpose

Election difficultly is no longer present in P6, which causes failure of parameter parsing for `GET /v0/chainParameters`.

Since this is not used by the wallet anyhow, it is removed from the expected parameters.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
