### PR TITLE
[CBW-1083] Remove the 'fix' that manually removed backslashes from wallet recovery requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed election difficulty from expected chain parameters.
+- Fix string handling which broke unicode support.
 
 ## [1.1.0] - 2023-07-13
 

--- a/ConcordiumWallet/Service/Network/NetworkManager.swift
+++ b/ConcordiumWallet/Service/Network/NetworkManager.swift
@@ -158,7 +158,10 @@ final class NetworkManager: NetworkManagerProtocol {
             CookieJar.cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
         }
         
-        let json = try decoder.decode(String.self, from: data)
-        return try decoder.decode(T.self, from: Data(json.utf8))
+        if let json = try? decoder.decode(String.self, from: data) {
+            return try decoder.decode(T.self, from: Data(json.utf8))
+        } else {
+            return try decoder.decode(T.self, from: data)
+        }
     }
 }

--- a/ConcordiumWallet/Service/Network/NetworkManager.swift
+++ b/ConcordiumWallet/Service/Network/NetworkManager.swift
@@ -158,14 +158,14 @@ final class NetworkManager: NetworkManagerProtocol {
             CookieJar.cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
         }
         
-        if let result = try? decoder.decode(T.self, from: data) {
-            return result
+        do {
+            return decoder.decode(T.self, from: data)
+        } catch let err {
+            // In case of wallet recovery DTS double encodes the response and that's a workaround for this.
+            if let json = try? decoder.decode(String.self, from: data) {
+                return try decoder.decode(T.self, from: Data(json.utf8))
+            }
+            throw err
         }
-        // In case of wallet recovery DTS double encodes the response and that's a workaround for this.
-        if let json = try? decoder.decode(String.self, from: data) {
-            return try decoder.decode(T.self, from: Data(json.utf8))
-        }
-        // We know it will fail, called it to get expected error message.
-        return try decoder.decode(T.self, from: data)
     }
 }

--- a/ConcordiumWallet/Service/Network/NetworkManager.swift
+++ b/ConcordiumWallet/Service/Network/NetworkManager.swift
@@ -158,10 +158,14 @@ final class NetworkManager: NetworkManagerProtocol {
             CookieJar.cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
         }
         
+        if let result = try? decoder.decode(T.self, from: data) {
+            return result
+        }
+        // In case of wallet recovery DTS double encodes the response and that's a workaround for this.
         if let json = try? decoder.decode(String.self, from: data) {
             return try decoder.decode(T.self, from: Data(json.utf8))
-        } else {
-            return try decoder.decode(T.self, from: data)
         }
+        // We know it will fail, called it to get expected error message.
+        return try decoder.decode(T.self, from: data)
     }
 }

--- a/ConcordiumWallet/Service/Network/NetworkManager.swift
+++ b/ConcordiumWallet/Service/Network/NetworkManager.swift
@@ -117,20 +117,11 @@ final class NetworkManager: NetworkManagerProtocol {
                 throw NetworkError.dataLoadingError(statusCode: response.statusCode, data: data)
             }
             
-            var dataString = String(data: data, encoding: .utf8)!
-            dataString = dataString.replacingOccurrences(of: "\\", with: "")
-            if dataString.hasPrefix("\"") == true {
-                dataString = String(dataString.dropFirst())
-            }
-            if dataString.hasSuffix("\"") == true {
-                dataString = String(dataString.dropLast())
-            }
-            
             if let url = response.url, let fields = response.allHeaderFields as? [String: String] {
                 CookieJar.cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
             }
             
-            return try decoder.decode(T.self, from: Data(dataString.utf8))
+            return try decoder.decode(T.self, from: data)
         } catch {
             if error is DecodingError {
                 print("Decoding error: \(error)")
@@ -163,19 +154,11 @@ final class NetworkManager: NetworkManagerProtocol {
             throw NetworkError.dataLoadingError(statusCode: response.statusCode, data: data)
         }
         
-        var dataString = String(data: data, encoding: .utf8)!
-        dataString = dataString.replacingOccurrences(of: "\\", with: "")
-        if dataString.hasPrefix("\"") == true {
-            dataString = String(dataString.dropFirst())
-        }
-        if dataString.hasSuffix("\"") == true {
-            dataString = String(dataString.dropLast())
-        }
-        
         if let url = response.url, let fields = response.allHeaderFields as? [String: String] {
             CookieJar.cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
         }
         
-        return try decoder.decode(T.self, from: Data(dataString.utf8))
+        let json = try decoder.decode(String.self, from: data)
+        return try decoder.decode(T.self, from: Data(json.utf8))
     }
 }

--- a/ConcordiumWallet/Service/Network/NetworkManager.swift
+++ b/ConcordiumWallet/Service/Network/NetworkManager.swift
@@ -159,7 +159,7 @@ final class NetworkManager: NetworkManagerProtocol {
         }
         
         do {
-            return decoder.decode(T.self, from: data)
+            return try decoder.decode(T.self, from: data)
         } catch let err {
             // In case of wallet recovery DTS double encodes the response and that's a workaround for this.
             if let json = try? decoder.decode(String.self, from: data) {


### PR DESCRIPTION
## Purpose
It has been reported that for some of the identity providers unicode characters are displayed wrong. It was caused by the fix, that tried to 'walkaround' invalid JSON format that is sent by DTS, wrapping it in unecessary quotation marks.

Affects: https://concordium.atlassian.net/browse/CBW-1083

## Changes
I removed the fix that removed backslashes from json string.
I temporarily added support for cases where JSON is embedded within string.

