### PR TITLE
Fix baking and delegation on P6

### DIFF
--- a/ConcordiumWallet/Model/AutoGenerated/GASRewards.swift
+++ b/ConcordiumWallet/Model/AutoGenerated/GASRewards.swift
@@ -10,13 +10,11 @@ struct GASRewards: Codable {
     let chainUpdate: Double
     let accountCreation: Double
     let baker: Double
-    let finalizationProof: Double
 
     enum CodingKeys: String, CodingKey {
         case chainUpdate = "chainUpdate"
         case accountCreation = "accountCreation"
         case baker = "baker"
-        case finalizationProof = "finalizationProof"
     }
 }
 
@@ -41,14 +39,12 @@ extension GASRewards {
     func with(
         chainUpdate: Double? = nil,
         accountCreation: Double? = nil,
-        baker: Double? = nil,
-        finalizationProof: Double? = nil
+        baker: Double? = nil
     ) -> GASRewards {
         return GASRewards(
             chainUpdate: chainUpdate ?? self.chainUpdate,
             accountCreation: accountCreation ?? self.accountCreation,
-            baker: baker ?? self.baker,
-            finalizationProof: finalizationProof ?? self.finalizationProof
+            baker: baker ?? self.baker
         )
     }
 

--- a/ConcordiumWallet/Model/AutoGenerated/MakeCreateTransferRequest.swift
+++ b/ConcordiumWallet/Model/AutoGenerated/MakeCreateTransferRequest.swift
@@ -61,7 +61,7 @@ struct MakeCreateTransferRequest: Codable {
     let metadataURL: String?
     let transactionFeeCommission: String?
     let bakingRewardCommission: String?
-    let finalizationRewardCommission: Double?
+    let finalizationRewardCommission: String?
     let bakerKeys: GeneratedBakerKeys?
     let keys: AccountKeys?
     let energy: Int?
@@ -131,7 +131,7 @@ extension MakeCreateTransferRequest {
         metadataURL: String?? = nil,
         transactionFeeCommission: String?? = nil,
         bakingRewardCommission: String?? = nil,
-        finalizationRewardCommission: Double?? = nil,
+        finalizationRewardCommission: String?? = nil,
         bakerKeys: GeneratedBakerKeys?? = nil,
         keys: AccountKeys?? = nil,
         energy: Int?? = nil,

--- a/ConcordiumWallet/Service/MobileWallet.swift
+++ b/ConcordiumWallet/Service/MobileWallet.swift
@@ -274,7 +274,7 @@ class MobileWallet: MobileWalletProtocol {
             metadataURL: metadataURL,
             transactionFeeCommission: transactionFeeCommission?.string,
             bakingRewardCommission: bakingRewardCommission?.string,
-            finalizationRewardCommission: finalizationRewardCommission,
+            finalizationRewardCommission: finalizationRewardCommission?.string,
             bakerKeys: bakerKeys,
             keys: privateAccountKeys,
             energy: energy,


### PR DESCRIPTION
Removed field `finalizationProof` from `GASRewards` which was previously unused and from chain parameters v2 also [missing](https://developer.concordium.software/concordium-grpc-api/#concordium.v2.GasRewardsCpv2) from the API.

Also changed `finalizationRewardCommission` in `MakeCreateTransferRequest` to a string like it was previously done (in [`823955b`](https://github.com/Concordium/concordium-reference-wallet-ios/commit/823955bfb84d38a0e3689c01042b3c01b306d557#diff-e58c27121216c2044222445446d54233fddf1a2d5ccaea6fb4931b57e440e784R20)) for `transactionFeeCommission` and `bakingRewardCommission` to fix [CBW-659](https://concordium.atlassian.net/browse/CBW-659) as we saw that same issue again for this field.

Fixes [CBW-1143](https://concordium.atlassian.net/browse/CBW-1143).

[CBW-659]: https://concordium.atlassian.net/browse/CBW-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBW-1143]: https://concordium.atlassian.net/browse/CBW-1143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ