### PR TITLE
Revert changes that broke toggling of shilelded transfers

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsPresenter.swift
@@ -73,6 +73,7 @@ protocol AccountDetailsPresenterProtocol: AnyObject, AccountTokensPresenterProto
 
     func userSelectedGeneral()
     func userSelectedShieled()
+    func userSelectedTransfers()
     func showGTUDrop() -> Bool
     func createTransactionsDataPresenter() -> AccountTransactionsDataPresenter
     func updateTransfersOnChanges()
@@ -286,6 +287,10 @@ extension AccountDetailsPresenter: AccountDetailsPresenterProtocol {
             switchToBalanceType(.balance)
             updateTransfers()
         }
+    }
+    
+    func userSelectedTransfers() {
+        updateTransfers()
     }
 
     func createTransactionsDataPresenter() -> AccountTransactionsDataPresenter {

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
@@ -226,6 +226,10 @@ class AccountDetailsViewController: BaseViewController, AccountDetailsViewProtoc
 
         showTransferData(accountState: viewModel.accountState, isReadOnly: viewModel.isReadOnly, hasTransfers: viewModel.hasTransfers)
         
+        // HACK: Remnant from legacy wallet code that ensures the UI to be updated appropriately when shilded balances are enabled or hidden.
+        //       The value of 'selectedBalance' isn't actually ever written (nor read!); the reason this works is that
+        //       'switchToBalanceType', 'hideShieldedTapped' etc. re-binds the view model, causing the (hardcoded) value '.balance' to be republished.
+        //       Via this observer, 'updateTransfers' is called when this happens to refresh the UI at just the right time.
         viewModel.$selectedBalance
                 .sink { [weak self] _ in
                     self?.presenter.userSelectedTransfers()

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
@@ -229,11 +229,6 @@ class AccountDetailsViewController: BaseViewController, AccountDetailsViewProtoc
         viewModel.$selectedBalance
                 .sink { [weak self] _ in
                     self?.presenter.userSelectedTransfers()
-                    self?.showTransferData(
-                            accountState: viewModel.accountState,
-                            isReadOnly: viewModel.isReadOnly,
-                            hasTransfers: viewModel.hasTransfers
-                    )
                 }
                 .store(in: &cancellables)
 

--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
@@ -225,6 +225,17 @@ class AccountDetailsViewController: BaseViewController, AccountDetailsViewProtoc
         self.viewModel = viewModel
 
         showTransferData(accountState: viewModel.accountState, isReadOnly: viewModel.isReadOnly, hasTransfers: viewModel.hasTransfers)
+        
+        viewModel.$selectedBalance
+                .sink { [weak self] _ in
+                    self?.presenter.userSelectedTransfers()
+                    self?.showTransferData(
+                            accountState: viewModel.accountState,
+                            isReadOnly: viewModel.isReadOnly,
+                            hasTransfers: viewModel.hasTransfers
+                    )
+                }
+                .store(in: &cancellables)
 
         Publishers.CombineLatest(viewModel.$hasTransfers, viewModel.$accountState)
             .sink { [weak self] (hasTransfers: Bool, accountState: SubmissionStatusEnum) in


### PR DESCRIPTION
## Purpose

Ensure that toggling of the setting for displaying shielded transfers is picked up by the UI.

## Changes

Revert changes [#357](https://github.com/Concordium/concordium-reference-wallet-ios/pull/357/files#diff-2a831347698dfe816d7be4bcdb3b9208ab59a0cfaed29da4e3dbb6e93f326c00L223-L243) that broke toggling of shielded transfers.

Fixes https://concordium.atlassian.net/browse/CBW-1387.