### PR TITLE
[CBW-1528] & [CBW-1529] remove "Finalization reward commission" and Rename "Baking commission" label

### DIFF
--- a/ConcordiumWallet/Views/Stake/Baking/ComissionSettings/BakerCommissionSettingsView.swift
+++ b/ConcordiumWallet/Views/Stake/Baking/ComissionSettings/BakerCommissionSettingsView.swift
@@ -25,16 +25,10 @@ struct BakerCommissionSettingsView: View {
                     commission: $viewModel.transactionFeeCommission
                 )
 
-                Text("Baking reward commission")
+                Text("Block reward commission")
                 BakerCommissionSliderView(
                     range: ranges.bakingCommissionRange,
                     commission: $viewModel.bakingRewardCommission
-                )
-
-                Text("Finalization reward commission")
-                BakerCommissionSliderView(
-                    range: ranges.finalizationCommissionRange,
-                    commission: $viewModel.finalizationRewardCommission
                 )
                 Spacer()
                 Button(action: viewModel.continueButtonTapped) {

--- a/ConcordiumWallet/Views/Stake/Baking/ComissionSettings/BakerCommissionSettingsViewModel.swift
+++ b/ConcordiumWallet/Views/Stake/Baking/ComissionSettings/BakerCommissionSettingsViewModel.swift
@@ -22,15 +22,12 @@ extension NumberFormatter {
 enum BakerCommissionSettingError: LocalizedError {
     case transactionFeeOutOfRange
     case bakingRewardOutOfRange
-    case finalizationRewardOutOfRange
     case networkError(Error)
 
     var errorMessage: String {
         switch self {
         case .bakingRewardOutOfRange:
             return "Baking reward is out of specified range"
-        case .finalizationRewardOutOfRange:
-            return "Finalization reward is out of specified range"
         case .transactionFeeOutOfRange:
             return "Transaction fee is out of specified range"
         case let .networkError(error):
@@ -135,10 +132,6 @@ class BakerCommissionSettingsViewModel: ObservableObject {
 
         guard ranges.bakingCommissionRange.min ... ranges.bakingCommissionRange.max ~= bakingRewardCommission else {
             return BakerCommissionSettingError.bakingRewardOutOfRange
-        }
-
-        guard ranges.finalizationCommissionRange.min ... ranges.finalizationCommissionRange.max ~= finalizationRewardCommission else {
-            return BakerCommissionSettingError.finalizationRewardOutOfRange
         }
 
         guard ranges.transactionCommissionRange.min ... ranges.transactionCommissionRange.max ~= transactionFeeCommission else {


### PR DESCRIPTION
## Purpose
It was discussed to remove the Finalization reward commission from the flows as well as renaming  “Baking reward commission“ to “Block reward commission“

https://concordium.atlassian.net/browse/CBW-1528
https://concordium.atlassian.net/browse/CBW-1529

## Changes
after changes
![image](https://github.com/Concordium/concordium-reference-wallet-ios/assets/146744339/966db3a8-151e-4919-9197-f27639ad9a90)

