### PR TITLE
Update microphone usage description

### DIFF
--- a/ConcordiumWallet/Resources/ConcordiumWallet-mock-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWallet-mock-Info.plist
@@ -91,6 +91,6 @@
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
+	<string>To ensure a secure and seamless user experience, our app might use the microphone for a liveness check. The microphone is exclusively used during the identity creation process.</string>
 </dict>
 </plist>

--- a/ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist
@@ -79,6 +79,6 @@
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
+	<string>To ensure a secure and seamless user experience, our app might use the microphone for a liveness check. The microphone is exclusively used during the identity creation process.</string>
 </dict>
 </plist>

--- a/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
@@ -58,8 +58,6 @@
 	<string>Used to scan QR code and to take a picture for your identity</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Enable FaceID for more convenient login</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>RobotoMono.ttf</string>
@@ -84,5 +82,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>To ensure a secure and seamless user experience, our app might use the microphone for a liveness check. The microphone is exclusively used during the identity creation process.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Purpose
Apple rejected our app due to missing `Privacy - Microphone Usage Description`
## Changes
Added following message to info.plist files:
`To ensure a secure and seamless user experience, our app might use the microphone for a liveness check. The microphone is exclusively used during the identity creation process.`
