### PR TITLE
Feature/cbw 1218

### DIFF
--- a/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
+++ b/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
@@ -37,9 +37,9 @@ class WalletConnectCoordinator: Coordinator {
         )
         Pair.configure(metadata: metadata)
         Networking.configure(projectId: CONCORDIUM_WALLET_CONNECT_PROJECT_ID, socketFactory: SocketFactory())
-
+        
         nukeWalletConnectSessionsAndPairings()
-
+        
         setupWalletConnectRequestBinding()
         setupWalletConnectProposalBinding()
         setupWalletConnectSettleBinding()
@@ -113,7 +113,7 @@ private extension WalletConnectCoordinator {
 
                 let viewModel = WalletConnectAccountSelectViewModel(
                     storageManager: self.dependencyProvider.storageManager(),
-
+                    
                     didSelect: { [weak self] account in
                         self?.navigationController.pushViewController(
                             UIHostingController(
@@ -289,14 +289,14 @@ private extension WalletConnectCoordinator {
                     )
                     return
                 }
-
+                
                 // TODO: Extract functions.
                 switch request.method {
                 case signAndSendTransactionMethod:
                     break // continue below (done like this to ensure that PR only adds implementation of "sign_message" without changing any existing code)
                 case signMessageMethod:
                     // Handle method "sign_message".
-
+                    
                     var payload: SignMessagePayload
                     do {
                         // Converting from dict to ContractUpdateParams struct by serializing it to JSON
@@ -311,7 +311,7 @@ private extension WalletConnectCoordinator {
                         )
                         return
                     }
-
+                    
                     self?.navigationController.pushViewController(
                         UIHostingController(
                             rootView: WalletConnectApprovalView(
@@ -326,7 +326,7 @@ private extension WalletConnectCoordinator {
                                         guard let self else {
                                             return
                                         }
-
+                                        
                                         // Sign message and return signatures.
                                         dependencyProvider.mobileWallet()
                                             .signMessage(for: account, message: payload.message, requestPasswordDelegate: self)
@@ -363,7 +363,7 @@ private extension WalletConnectCoordinator {
                     )
                     return
                 }
-
+                
                 // Handle method "sign_and_send_transaction".
 
                 var params: ContractUpdateParams
@@ -396,7 +396,7 @@ private extension WalletConnectCoordinator {
                     )
                     return
                 }
-
+                
                 var message: SignableValueRepresentation?
                 if !inputParams.parameter.isEmpty {
                     if let decoded = try? self?.dependencyProvider.transactionsService().decodeContractParameter(with: inputParams).data(using: .utf8)?.prettyPrintedJSONString {
@@ -442,7 +442,7 @@ private extension WalletConnectCoordinator {
                 transfer.energy = params.payload.maxContractExecutionEnergy // may get overwritten by result from WP's cost estimation.
 
                 let info = TransferInfo() // initialize info with no cost estimation
-
+                
                 let isAccountBalanceSufficient = account.forecastAtDisposalBalance > amount
 
                 if let self {
@@ -505,7 +505,7 @@ private extension WalletConnectCoordinator {
                     },
                     shouldAllowAccept: info.$estimatedCost.map { $0 != nil && isAccountBalanceSufficient }.eraseToAnyPublisher()
                 )
-
+                
                 self?.navigationController.pushViewController(
                     UIHostingController(
                         // TODO: Only enable "Accept" button after cost estimation has been resolved.
@@ -674,7 +674,7 @@ extension WalletConnectCoordinator: WalletConnectDelegate {
                 self?.parentCoordinator?.dismissWalletConnectCoordinator()
             }
         }
-
+        
         navigationController.popToRootViewController(animated: true)
         parentCoordinator?.dismissWalletConnectCoordinator() // disconnects any sessions
         presentError(with: "errorAlert.title".localized, message: msg)


### PR DESCRIPTION
## Purpose
For safety, it is important to not allow dApps to send requests upon other request. It can mislead a user and make him accept request, that he/she would've otherwise not approved. 

## Changes
In order to prevent that, a bool flag has been added and is set `true` when a request is pending. After it's rejected or accepted, the flag is set back to false.

Jira ticket: https://concordium.atlassian.net/browse/CBW-1218