### PR TITLE
[CBW-1480] Disable shielded balance under Fungible tab

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountTokens/AccountTokensViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountTokens/AccountTokensViewController.swift
@@ -77,7 +77,7 @@ class AccountTokensViewController: BaseViewController, Storyboarded {
                     .init(
                         contractName: "",
                         tokenId: "",
-                        balance: BigInt(presenter.account.totalForecastBalance),
+                        balance: BigInt(presenter.account.finalizedBalance),
                         contractIndex: "",
                         name: "CCD",
                         symbol: "CCD",


### PR DESCRIPTION
## Purpose
CCD balance under Fungible tab should not include shielded balance, it should show same value as “Balance total”
## Changes
Now the label show `finalizedBalance` instead of `forecastTotalBalance`