### PR TITLE
[CBW-1125] Update balance on signature approval screen

### DIFF
--- a/ConcordiumWallet/Service/Network/NetworkManagerProtocol.swift
+++ b/ConcordiumWallet/Service/Network/NetworkManagerProtocol.swift
@@ -69,7 +69,7 @@ extension NetworkManagerProtocol {
 }
 
 /// Defines the Network service errors.
-enum NetworkError: Error {
+enum NetworkError: Error, Identifiable {
     case invalidRequest
     case communicationError(error: Error)
     case invalidResponse
@@ -77,4 +77,23 @@ enum NetworkError: Error {
     case serverError(error: ServerErrorMessage)
     case jsonDecodingError(error: Error)
     case timeOut
+
+    var id: String {
+          switch self {
+          case .invalidRequest:
+              return "invalidRequest"
+          case .communicationError(let error):
+              return "communicationError-\(error.localizedDescription)"
+          case .invalidResponse:
+              return "invalidResponse"
+          case .dataLoadingError(let statusCode, _):
+              return "dataLoadingError-\(statusCode)"
+          case .serverError(let error):
+              return "serverError-\(error)"
+          case .jsonDecodingError(let error):
+              return "jsonDecodingError-\(error.localizedDescription)"
+          case .timeOut:
+              return "timeOut"
+          }
+      }
 }

--- a/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
+++ b/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
@@ -513,7 +513,7 @@ private extension WalletConnectCoordinator {
                             title: "Transaction Approval",
                             contentView: WalletConnectActionRequestView(
                                 /// This Self has been guarded in separete PR, thus I allow myself to force unwrap it here as there'll merge conflict on this anyway.
-                                service: self!.dependencyProvider.accountsService(),
+                                service: self.dependencyProvider.accountsService(),
                                 dappName: session.peer.name,
                                 account: account,
                                 amount: GTU(intValue: amount),

--- a/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
+++ b/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
@@ -512,9 +512,10 @@ private extension WalletConnectCoordinator {
                         rootView: WalletConnectApprovalView(
                             title: "Transaction Approval",
                             contentView: WalletConnectActionRequestView(
+                                /// This Self has been guarded in separete PR, thus I allow myself to force unwrap it here as there'll merge conflict on this anyway.
+                                service: self!.dependencyProvider.accountsService(),
                                 dappName: session.peer.name,
-                                accountName: account.displayName,
-                                balanceAtDisposal: GTU(intValue: account.forecastAtDisposalBalance),
+                                account: account,
                                 amount: GTU(intValue: amount),
                                 contractAddress: params.payload.address,
                                 transactionType: params.type.rawValue,

--- a/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
+++ b/ConcordiumWallet/Views/WalletConnect/WalletConnectCoordinator.swift
@@ -512,7 +512,6 @@ private extension WalletConnectCoordinator {
                         rootView: WalletConnectApprovalView(
                             title: "Transaction Approval",
                             contentView: WalletConnectActionRequestView(
-                                /// This Self has been guarded in separete PR, thus I allow myself to force unwrap it here as there'll merge conflict on this anyway.
                                 service: self.dependencyProvider.accountsService(),
                                 dappName: session.peer.name,
                                 account: account,

--- a/ioscommon/Commons/RealmHelper.swift
+++ b/ioscommon/Commons/RealmHelper.swift
@@ -13,7 +13,7 @@ struct RealmHelper {
     
     // Set the new schema version. This must be greater than the previously used
     // version (if you've never set a schema version before, the version is 0).
-    private static let schemaVersion: UInt64 = 26
+    private static let schemaVersion: UInt64 = 32
 
     static let realmConfiguration = Realm.Configuration(
         schemaVersion: schemaVersion,


### PR DESCRIPTION
## Purpose
When app is in WalletConnect session it keeps on showing the same balance as it was at the time of establishing connection for each request.
## Changes
I added fetching of account balance for each request so it should the most up to date amount.
