### PR TITLE
[CBW-1388] show as long as there’s no transaction log on this screen

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
+++ b/ConcordiumWallet/Views/AccountsView/AccountDetails/AccountDetailsViewController.swift
@@ -86,10 +86,7 @@ class AccountDetailsViewController: BaseViewController, AccountDetailsViewProtoc
         viewModel.$selectedSection.map { $0 != .tokens }
             .assign(to: \.isHidden, on: accountTokensViewController.view)
             .store(in: &cancellables)
-        
-        viewModel.$selectedSection.map { $0 != .transfers }
-            .assign(to: \.isHidden, on: transactionsVC.view)
-            .store(in: &cancellables)
+
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Purpose

Option to request for CCD should be shown as long as there’s no transaction log on this screen. 
## Changes
There was unnecessary setting of `isHidden` bool for transaction list view. It has been removed.
