### PR TITLE
Update fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,9 +29,7 @@ platform :ios do
       app_store_connect_api_key(
         key_id: ENV["APPLE_KEY_ID"],
         issuer_id: ENV['APPLE_KEY_ISSUER'],
-        #in_house: false,
         key_content: ENV['APPLE_API_KEY'],
-        #is_key_content_base64: true
       )
       increment_build_number(
         build_number: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,9 +29,9 @@ platform :ios do
       app_store_connect_api_key(
         key_id: ENV["APPLE_KEY_ID"],
         issuer_id: ENV['APPLE_KEY_ISSUER'],
-        in_house: false,
+        #in_house: false,
         key_content: ENV['APPLE_API_KEY'],
-        is_key_content_base64: true
+        #is_key_content_base64: true
       )
       increment_build_number(
         build_number: [


### PR DESCRIPTION
## Purpose

Update fastlane

## Changes

Update fastlane  `app_store_connect_api_key` in `upload_build ` lane,  to use App Store Connect API as `key_content ` without any manipulation with .p8 data itself. 
[latest fastlane docs](http://docs.fastlane.tools/actions/app_store_connect_api_key/)

