### PR TITLE
Add encryption export compliance code

### DIFF
--- a/ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletMainNet-Info.plist
@@ -37,6 +37,8 @@
 	<string>idiss@concordium.software</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
+	<key>ITSEncryptionExportComplianceCode</key>
+	<string>84d45e84-393e-4e06-b0f4-eb9b3026bf66</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletStagingNet-Info.plist
@@ -43,6 +43,8 @@
 	<string>idiss@concordium.software</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
+	<key>ITSEncryptionExportComplianceCode</key>
+	<string>6a4b12a4-5886-4e16-a74e-aed598cc486e</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
+++ b/ConcordiumWallet/Resources/ConcordiumWalletTestNet-Info.plist
@@ -43,6 +43,8 @@
 	<string>idiss@concordium.software</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
+	<key>ITSEncryptionExportComplianceCode</key>
+	<string>b542dc01-e05d-4057-9f23-660c240d57e2</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
## Purpose

To release an app we need to specify `App Encryption Export Compliance Code`  in app .plist

## Changes

Add export code for all targets
