### PR TITLE
Fix `Send All` button logic, while sending ccd's

### DIFF
--- a/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
+++ b/ConcordiumWallet/Views/AccountsView/SendFunds/SendFund/SendFundPresenter.swift
@@ -580,6 +580,10 @@ class SendFundPresenter: SendFundPresenterProtocol {
                     totalAmount = (GTU(intValue: disposalAmount) - cost).displayValue()
                 }
                 self.viewModel.sendAllAmount = totalAmount
+                
+                let newAmount = SendFundsAmount.ccd(token: GTU(intValue: disposalAmount) - cost)
+                self.viewModel.enteredAmount = .success(newAmount)
+                
                 self.cost = cost
                 self.energy = value.energy
                 let feeMessage = "sendFund.feeMessage".localized + cost.displayValue()


### PR DESCRIPTION
## Purpose

The Send All button currently does not trigger the logic chain needed to update its state.


## Changes

Added functionality to update the Send button state after the amount to send value is changed.